### PR TITLE
DEP-28 에러로깅 센트리 연동

### DIFF
--- a/Api/build.gradle
+++ b/Api/build.gradle
@@ -17,6 +17,8 @@ dependencies {
     implementation project(':Domain')
     implementation project(':Core')
     implementation project(':Infrastructure')
+    implementation 'io.sentry:sentry-spring-boot-starter:6.20.0'
+    implementation 'io.sentry:sentry-logback:6.20.0'
 }
 
 test {

--- a/Api/src/main/java/com/dingdong/api/example/HealthCheckController.java
+++ b/Api/src/main/java/com/dingdong/api/example/HealthCheckController.java
@@ -4,7 +4,10 @@ package com.dingdong.api.example;
 import com.dingdong.api.example.dto.HealthCheckResponse;
 import com.dingdong.core.exception.ExampleException;
 import io.swagger.v3.oas.annotations.Operation;
+
 import java.util.Objects;
+
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -12,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping(value = "/health")
+@Slf4j
 public class HealthCheckController {
 
     @Operation(summary = "테스트용 컨트롤러입니다.")
@@ -22,4 +26,11 @@ public class HealthCheckController {
         }
         return HealthCheckResponse.from("health");
     }
+
+    @Operation(summary = "테스트용 컨트롤러입니다.")
+    @GetMapping("/error")
+    public void healthCheck() {
+        log.error("test error");
+    }
+
 }

--- a/Api/src/main/resources/application.yml
+++ b/Api/src/main/resources/application.yml
@@ -10,3 +10,7 @@ spring:
 swagger:
   user: ${SWAGGER_USER:user}
   password: ${SWAGGER_PASSWORD:password}
+
+sentry:
+  dsn: ${DSN_KEY}
+  enable-tracing: true

--- a/Api/src/main/resources/logback-spring.xml
+++ b/Api/src/main/resources/logback-spring.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- Configure the Console appender -->
+    <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Configure the Sentry appender, overriding the logging threshold to the WARN level -->
+    <appender name="Sentry" class="io.sentry.logback.SentryAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+        <!-- Optionally add an encoder -->
+        <encoder>
+            <pattern>%-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Enable the Console and Sentry appenders, Console is provided as an example
+ of a non-Sentry logger that is set to a different logging threshold -->
+    <root level="INFO">
+        <appender-ref ref="Console"/>
+        <appender-ref ref="Sentry"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## 개요
- [DEP-28](https://darae0730.atlassian.net/jira/software/c/projects/DEP/issues/DEP-28?filter=allissues)

## 작업사항
- 에러 로깅을 위한 센트리 연동
- [센트리](https://no-n7u.sentry.io/projects/ding-dong-be/?project=4505265664884736)에서 확인가능

## 확인사항
![image](https://github.com/depromeet/Ding-dong-BE/assets/74492426/e2d63669-b75f-4dbd-a530-c9228a4e556c)
![image](https://github.com/depromeet/Ding-dong-BE/assets/74492426/1e50a441-5141-46f2-a993-4510d71b46d7)

잘 나오는 것 확인헀고, 젤 첫 이미지의 타이틀 같은 경우 logback-spring.xml에서 커스텀 가능하니 피드백 주시면 반영하겠습니당~!

