### PR TITLE
DEP-62: 주민증 생성 스키마 작성

### DIFF
--- a/Api/src/main/java/com/dingdong/api/config/GlobalExceptionHandler.java
+++ b/Api/src/main/java/com/dingdong/api/config/GlobalExceptionHandler.java
@@ -1,6 +1,5 @@
 package com.dingdong.api.config;
 
-
 import static com.dingdong.core.consts.StaticVal.BAD_REQUEST;
 
 import com.dingdong.core.dto.ErrorDetail;
@@ -12,16 +11,12 @@ import java.io.IOException;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import org.springframework.web.context.request.ServletWebRequest;
-import org.springframework.web.context.request.WebRequest;
-import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @RestControllerAdvice
@@ -57,18 +52,18 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     protected ResponseEntity<ErrorResponse> argumentNotValidHandle(
-        MethodArgumentNotValidException exception) {
+            MethodArgumentNotValidException exception) {
         ErrorDetail reason =
-            ErrorDetail.builder()
-                .statusCode(BAD_REQUEST)
-                .errorCode("Global-400-1")
-                .reason(
-                    exception
-                        .getBindingResult()
-                        .getAllErrors()
-                        .get(0)
-                        .getDefaultMessage())
-                .build();
+                ErrorDetail.builder()
+                        .statusCode(BAD_REQUEST)
+                        .errorCode("Global-400-1")
+                        .reason(
+                                exception
+                                        .getBindingResult()
+                                        .getAllErrors()
+                                        .get(0)
+                                        .getDefaultMessage())
+                        .build();
         ErrorResponse errorResponse = new ErrorResponse(reason);
         return ResponseEntity.status(errorResponse.getStatusCode()).body(errorResponse);
     }

--- a/Api/src/main/java/com/dingdong/api/idcard/controller/IdCardController.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/controller/IdCardController.java
@@ -34,6 +34,7 @@ public class IdCardController {
     @Operation(summary = "주민증 생성")
     @PostMapping
     public Void postIdCard(@RequestBody @Valid CreateIdCardRequest body) {
+        //Todo: 유저 id값은 나중에 로그인 기능 완성되고 AccessToken 필터 추가 되면 거기서 가져오기
         return null;
     }
 }

--- a/Api/src/main/java/com/dingdong/api/idcard/controller/IdCardController.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/controller/IdCardController.java
@@ -34,7 +34,7 @@ public class IdCardController {
     @Operation(summary = "주민증 생성")
     @PostMapping
     public Void postIdCard(@RequestBody @Valid CreateIdCardRequest body) {
-        //Todo: 유저 id값은 나중에 로그인 기능 완성되고 AccessToken 필터 추가 되면 거기서 가져오기
+        // Todo: 유저 id값은 나중에 로그인 기능 완성되고 AccessToken 필터 추가 되면 거기서 가져오기
         return null;
     }
 }

--- a/Api/src/main/java/com/dingdong/api/idcard/controller/IdCardController.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/controller/IdCardController.java
@@ -1,12 +1,16 @@
 package com.dingdong.api.idcard.controller;
 
 
+import com.dingdong.api.idcard.controller.request.CreateIdCardRequest;
 import com.dingdong.api.idcard.controller.response.CommentCountResponse;
 import com.dingdong.api.idcard.controller.response.IdCardDetailsResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import javax.validation.Valid;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,5 +29,11 @@ public class IdCardController {
     @GetMapping("/{idCardsId}/comment-count")
     public CommentCountResponse getCommentCount(@PathVariable Long idCardsId) {
         return new CommentCountResponse();
+    }
+
+    @Operation(summary = "주민증 생성")
+    @PostMapping
+    public Void postIdCard(@RequestBody @Valid CreateIdCardRequest body) {
+        return null;
     }
 }

--- a/Api/src/main/java/com/dingdong/api/idcard/controller/IdCardController.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/controller/IdCardController.java
@@ -33,8 +33,7 @@ public class IdCardController {
 
     @Operation(summary = "주민증 생성")
     @PostMapping
-    public Void postIdCard(@RequestBody @Valid CreateIdCardRequest body) {
+    public void postIdCard(@RequestBody @Valid CreateIdCardRequest body) {
         // Todo: 유저 id값은 나중에 로그인 기능 완성되고 AccessToken 필터 추가 되면 거기서 가져오기
-        return null;
     }
 }

--- a/Api/src/main/java/com/dingdong/api/idcard/controller/request/CreateIdCardRequest.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/controller/request/CreateIdCardRequest.java
@@ -1,0 +1,29 @@
+package com.dingdong.api.idcard.controller.request;
+
+import com.dingdong.api.idcard.dto.CreateKeywordDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CreateIdCardRequest {
+
+    @Schema(description = "행성에서 사용할 유저 닉네임", example = "김민준")
+    @NotNull(message = "행성에서 사용할 유저 닉네임을 입력해주세요.")
+    private String nickname;
+
+    @Schema(description = "유저 간단 자기소개", example = "안녕하세요. 김민준입니다.")
+    @NotNull(message = "유저 자기소개를 입력해주세요.")
+    @Size(max = 500, message = "자기소개는 500글자 제한입니다.")
+    private String aboutMe;
+
+    @Schema(description = "유저가 선택한 키워드와 키워드 설명글 리스트")
+    @NotNull(message = "적어도 한 개의 키워드는 선택해야 합니다.")
+    @Valid
+    private List<CreateKeywordDto> keywords;
+}

--- a/Api/src/main/java/com/dingdong/api/idcard/controller/request/CreateIdCardRequest.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/controller/request/CreateIdCardRequest.java
@@ -13,6 +13,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class CreateIdCardRequest {
 
+    @Schema(description = "행성 id", example = "1")
+    @NotNull(message = "행성 식별 값을 입력해주세요.")
+    private Long communityId;
+
     @Schema(description = "행성에서 사용할 유저 닉네임", example = "김민준")
     @NotNull(message = "행성에서 사용할 유저 닉네임을 입력해주세요.")
     private String nickname;

--- a/Api/src/main/java/com/dingdong/api/idcard/controller/request/CreateIdCardRequest.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/controller/request/CreateIdCardRequest.java
@@ -20,8 +20,7 @@ public class CreateIdCardRequest {
     private Long communityId;
 
     @Schema(description = "행성에서 사용할 유저 닉네임", example = "김민준")
-    @NotNull(message = "행성에서 사용할 유저 닉네임을 입력해주세요.")
-    @NotBlank(message = "유저 닉네임에 공백은 허용하지 않습니다.")
+    @NotBlank(message = "행성에서 사용할 유저 닉네임을 입력해주세요. 공백은 허용하지 않습니다.")
     private String nickname;
 
     @Schema(description = "유저 간단 자기소개", example = "안녕하세요. 김민준입니다.")

--- a/Api/src/main/java/com/dingdong/api/idcard/controller/request/CreateIdCardRequest.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/controller/request/CreateIdCardRequest.java
@@ -5,6 +5,7 @@ import com.dingdong.api.idcard.dto.CreateKeywordDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import lombok.Getter;
@@ -20,6 +21,7 @@ public class CreateIdCardRequest {
 
     @Schema(description = "행성에서 사용할 유저 닉네임", example = "김민준")
     @NotNull(message = "행성에서 사용할 유저 닉네임을 입력해주세요.")
+    @NotBlank(message = "유저 닉네임에 공백은 허용하지 않습니다.")
     private String nickname;
 
     @Schema(description = "유저 간단 자기소개", example = "안녕하세요. 김민준입니다.")

--- a/Api/src/main/java/com/dingdong/api/idcard/controller/request/CreateIdCardRequest.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/controller/request/CreateIdCardRequest.java
@@ -1,5 +1,6 @@
 package com.dingdong.api.idcard.controller.request;
 
+
 import com.dingdong.api.idcard.dto.CreateKeywordDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;

--- a/Api/src/main/java/com/dingdong/api/idcard/dto/CreateKeywordDto.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/dto/CreateKeywordDto.java
@@ -1,0 +1,20 @@
+package com.dingdong.api.idcard.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class CreateKeywordDto {
+
+    @Schema(description = "키워드 제목", example = "안산러")
+    @NotNull(message = "키워드 이름을 입력해주세요")
+    private String title;
+
+    @Schema(description = "키워드 이미지", example = "test.com")
+    private String imageUrl;
+
+    @Schema(description = "키워드 내용", example = "안산에서 통학하는 불쌍한 영혼을 구제해주세요... 내일도 학교가야함")
+    @NotNull(message = "키워드 설명을 적어주세요")
+    private String content;
+}

--- a/Api/src/main/java/com/dingdong/api/idcard/dto/CreateKeywordDto.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/dto/CreateKeywordDto.java
@@ -1,5 +1,6 @@
 package com.dingdong.api.idcard.dto;
 
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.NotNull;
 import lombok.Getter;

--- a/Domain/src/main/java/com/dingdong/domain/domains/idcard/domain/IdCard.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/idcard/domain/IdCard.java
@@ -30,8 +30,7 @@ public class IdCard extends AbstractTimeStamp {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @NotNull
-    private Long communityId;
+    @NotNull private Long communityId;
 
     @Embedded private UserInfo userInfo;
 

--- a/Domain/src/main/java/com/dingdong/domain/domains/idcard/domain/IdCard.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/idcard/domain/IdCard.java
@@ -15,6 +15,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -29,6 +30,9 @@ public class IdCard extends AbstractTimeStamp {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @NotNull
+    private Long communityId;
+
     @Embedded private UserInfo userInfo;
 
     @Enumerated(EnumType.STRING)
@@ -37,12 +41,13 @@ public class IdCard extends AbstractTimeStamp {
     @OneToMany(mappedBy = "idCard", cascade = CascadeType.ALL, orphanRemoval = true)
     private final List<Keyword> keywords = new ArrayList<>();
 
-    private IdCard(UserInfo userInfo, CharacterType character) {
+    private IdCard(Long communityId, UserInfo userInfo, CharacterType character) {
+        this.communityId = communityId;
         this.userInfo = userInfo;
         this.character = character;
     }
 
-    public static IdCard toEntity(UserInfo userInfo, CharacterType character) {
-        return new IdCard(userInfo, character);
+    public static IdCard toEntity(Long communityId, UserInfo userInfo, CharacterType character) {
+        return new IdCard(communityId, userInfo, character);
     }
 }


### PR DESCRIPTION
## 개요
- [DEP-62: 주민증 생성 API 스키마 작성](https://darae0730.atlassian.net/jira/software/c/projects/DEP/boards/2/roadmap?selectedIssue=DEP-62)

## 작업사항
- 주민증 생성 API 스키마를 작성했습니다.
- communityId는 뎁스 상 경로변수로 받으려 했는데 /id-card/community/1 이건 좀 이상해서 일단은 body에 넣어놨습니다.
- validation 체크 걸어주었습니다.
- 한가지 걸리는 점은 dto 리스트를 검증하기 위해 valid 어노테이션을 request class 안에다가도 넣어놨는데 과연 이게 맞는가 입니다. 그래도 dto 써서 바인딩 하는것이 훨씬 낫다고 생각하기 때문에 진행했습니다.
``` java
    @Schema(description = "유저가 선택한 키워드와 키워드 설명글 리스트")
    @NotNull(message = "적어도 한 개의 키워드는 선택해야 합니다.")
    @Valid
    private List<CreateKeywordDto> keywords;
```
- MethodArgumentNotValidException 에러를 처리하기 위해 에러 처리 로직을 추가했습니다.

## 변경로직
- 내용을 적어주세요.