### PR TITLE
DEP-51: 홈페이지 API 명세서 수정

### DIFF
--- a/Api/src/main/java/com/dingdong/api/community/dto/CommunityListDto.java
+++ b/Api/src/main/java/com/dingdong/api/community/dto/CommunityListDto.java
@@ -10,11 +10,17 @@ public class CommunityListDto {
     private Long communityId;
 
     @Schema(description = "썸네일 이미지")
-    private String thumbnailImageUrl;
+    private String logoImageUrl;
 
     @Schema(description = "커버 이미지")
     private String coverImageUrl;
 
     @Schema(description = "커뮤니티 이름")
     private String title;
+
+    @Schema(description = "주민 수")
+    private int idCardCount;
+
+    @Schema(description = "소개 글")
+    private String description;
 }

--- a/Domain/src/main/java/com/dingdong/domain/domains/community/domain/Community.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/community/domain/Community.java
@@ -40,6 +40,8 @@ public class Community extends AbstractTimeStamp {
 
     @Embedded private CommunityImage communityImage;
 
+    private String description;
+
     private String invitationCode;
 
     private Community(String name, CommunityImage communityImage, String invitationCode) {

--- a/Domain/src/main/java/com/dingdong/domain/domains/community/domain/CommunityImage.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/community/domain/CommunityImage.java
@@ -7,6 +7,6 @@ import lombok.Getter;
 @Embeddable
 @Getter
 public class CommunityImage {
-    private String profileImageUrl;
+    private String logoImageUrl;
     private String coverImageUrl;
 }


### PR DESCRIPTION
## 개요
- https://github.com/depromeet/Ding-dong-BE/pull/10

## 작업사항
![image](https://github.com/depromeet/Ding-dong-BE/assets/74492426/165f4506-aac0-4a1c-84e5-fc228ae6a3c4)
디자인에서 커뮤니티 소개 글과 주민 수가 추가되었음

## 변경로직
- Community에 description 컬럼 추가
- 명세 반환 값 추가 