### PR TITLE
DEP-82: 주민증 상세 조회 API 구현

### DIFF
--- a/Api/src/main/java/com/dingdong/api/idcard/controller/IdCardController.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/controller/IdCardController.java
@@ -4,11 +4,13 @@ package com.dingdong.api.idcard.controller;
 import com.dingdong.api.idcard.controller.request.CreateIdCardRequest;
 import com.dingdong.api.idcard.controller.response.CommentCountResponse;
 import com.dingdong.api.idcard.controller.response.IdCardDetailsResponse;
-import com.dingdong.api.idcard.service.CreateIdCardService;
+import com.dingdong.api.idcard.service.IdCardService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+
 import javax.validation.Valid;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -24,12 +26,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class IdCardController {
 
-    private final CreateIdCardService createIdCardService;
+    private final IdCardService idCardService;
 
     @Operation(summary = "주민증 세부 조회")
     @GetMapping("/{idCardsId}")
     public IdCardDetailsResponse getIdCardDetails(@PathVariable Long idCardsId) {
-        return new IdCardDetailsResponse();
+        return IdCardDetailsResponse.from(idCardService.getIdCardDetails(idCardsId));
     }
 
     @Operation(summary = "댓글 갯수 조회")
@@ -41,6 +43,6 @@ public class IdCardController {
     @Operation(summary = "주민증 생성")
     @PostMapping
     public void postIdCard(@RequestBody @Valid CreateIdCardRequest body) {
-        createIdCardService.execute(body);
+        idCardService.createIdCard(body);
     }
 }

--- a/Api/src/main/java/com/dingdong/api/idcard/controller/IdCardController.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/controller/IdCardController.java
@@ -8,9 +8,7 @@ import com.dingdong.api.idcard.service.IdCardService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-
 import javax.validation.Valid;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;

--- a/Api/src/main/java/com/dingdong/api/idcard/controller/response/IdCardDetailsResponse.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/controller/response/IdCardDetailsResponse.java
@@ -9,4 +9,11 @@ import lombok.Getter;
 public class IdCardDetailsResponse {
     @Schema(description = "주민증 세부 내용")
     private IdCardDetailsDto idCardDetailsDto;
+
+    public static IdCardDetailsResponse from(IdCardDetailsDto idCardDetailsDto) {
+        IdCardDetailsResponse response = new IdCardDetailsResponse();
+        response.idCardDetailsDto = idCardDetailsDto;
+
+        return response;
+    }
 }

--- a/Api/src/main/java/com/dingdong/api/idcard/dto/IdCardDetailsDto.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/dto/IdCardDetailsDto.java
@@ -4,10 +4,8 @@ package com.dingdong.api.idcard.dto;
 import com.dingdong.domain.domains.idcard.domain.entity.IdCard;
 import com.dingdong.domain.domains.idcard.domain.enums.CharacterType;
 import io.swagger.v3.oas.annotations.media.Schema;
-
 import java.util.ArrayList;
 import java.util.List;
-
 import lombok.Getter;
 
 @Getter

--- a/Api/src/main/java/com/dingdong/api/idcard/dto/IdCardDetailsDto.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/dto/IdCardDetailsDto.java
@@ -1,10 +1,13 @@
 package com.dingdong.api.idcard.dto;
 
 
+import com.dingdong.domain.domains.idcard.domain.entity.IdCard;
 import com.dingdong.domain.domains.idcard.domain.enums.CharacterType;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.ArrayList;
 import java.util.List;
+
 import lombok.Getter;
 
 @Getter
@@ -26,4 +29,17 @@ public class IdCardDetailsDto {
 
     @Schema(description = "캐릭터 타입")
     private CharacterType characterType;
+
+    public static IdCardDetailsDto of(IdCard idCard, List<KeywordDto> keywordDtos) {
+        IdCardDetailsDto dto = new IdCardDetailsDto();
+
+        dto.idCardId = idCard.getId();
+        dto.nickname = idCard.getNickname();
+        dto.profileImageUrl = idCard.getProfileImageUrl();
+        dto.aboutMe = idCard.getAboutMe();
+        dto.keywords = keywordDtos;
+        dto.characterType = idCard.getCharacterType();
+
+        return dto;
+    }
 }

--- a/Api/src/main/java/com/dingdong/api/idcard/dto/KeywordDto.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/dto/KeywordDto.java
@@ -1,6 +1,7 @@
 package com.dingdong.api.idcard.dto;
 
 
+import com.dingdong.domain.domains.idcard.domain.entity.Keyword;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
@@ -17,4 +18,14 @@ public class KeywordDto {
 
     @Schema(description = "키워드 내용")
     private String content;
+
+    public static KeywordDto of(Keyword keyword) {
+        KeywordDto dto = new KeywordDto();
+        dto.keywordId = keyword.getId();
+        dto.title = keyword.getTitle();
+        dto.imageUrl = keyword.getImagerUrl();
+        dto.content = keyword.getContent();
+
+        return dto;
+    }
 }

--- a/Api/src/main/java/com/dingdong/api/idcard/service/IdCardService.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/service/IdCardService.java
@@ -13,10 +13,8 @@ import com.dingdong.domain.domains.idcard.domain.entity.IdCard;
 import com.dingdong.domain.domains.idcard.domain.entity.Keyword;
 import com.dingdong.domain.domains.idcard.validator.IdCardValidator;
 import com.dingdong.domain.domains.user.domain.User;
-
 import java.util.List;
 import java.util.stream.Collectors;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -34,22 +32,17 @@ public class IdCardService {
 
     private final CommunityAdaptor communityAdaptor;
 
-    /**
-     * 주민증 세부 조회
-     */
+    /** 주민증 세부 조회 */
     public IdCardDetailsDto getIdCardDetails(Long idCardsId) {
         IdCard idCard = idCardAdaptor.findById(idCardsId);
 
-        List<KeywordDto> keywordDtos = idCard.getKeywords().stream()
-                .map(KeywordDto::of)
-                .collect(Collectors.toList());
+        List<KeywordDto> keywordDtos =
+                idCard.getKeywords().stream().map(KeywordDto::of).collect(Collectors.toList());
 
         return IdCardDetailsDto.of(idCard, keywordDtos);
     }
 
-    /**
-     * 주민증 생성
-     */
+    /** 주민증 생성 */
     @Transactional
     public void createIdCard(CreateIdCardRequest request) {
 
@@ -71,9 +64,7 @@ public class IdCardService {
         saveIdCard.updateKeywords(createKeywords(request.getKeywords(), saveIdCard.getId()));
     }
 
-    /**
-     * idCard 생성 시 커뮤니티 찾고 해당 커뮤니티에 유저가 주민증을 만들었는지 여부 검사
-     */
+    /** idCard 생성 시 커뮤니티 찾고 해당 커뮤니티에 유저가 주민증을 만들었는지 여부 검사 */
     private Community findAndValidateCommunity(Long communityId, Long currentUserId) {
         // community validation
         Community community = communityAdaptor.findById(communityId);
@@ -84,9 +75,7 @@ public class IdCardService {
         return community;
     }
 
-    /**
-     * idCard 생성 및 저장
-     */
+    /** idCard 생성 및 저장 */
     private IdCard createAndSaveIdCard(
             Long communityId,
             User currentUser,
@@ -108,9 +97,7 @@ public class IdCardService {
         return idCardAdaptor.save(idCard);
     }
 
-    /**
-     * keyword 리스트 생성
-     */
+    /** keyword 리스트 생성 */
     private List<Keyword> createKeywords(List<CreateKeywordDto> keywordDtos, Long idCardId) {
         return keywordDtos.stream()
                 .map(

--- a/Api/src/main/java/com/dingdong/api/idcard/service/IdCardService.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/service/IdCardService.java
@@ -14,7 +14,6 @@ import com.dingdong.domain.domains.idcard.domain.entity.Keyword;
 import com.dingdong.domain.domains.idcard.validator.IdCardValidator;
 import com.dingdong.domain.domains.user.domain.User;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,8 +35,7 @@ public class IdCardService {
     public IdCardDetailsDto getIdCardDetails(Long idCardsId) {
         IdCard idCard = idCardAdaptor.findById(idCardsId);
 
-        List<KeywordDto> keywordDtos =
-                idCard.getKeywords().stream().map(KeywordDto::of).collect(Collectors.toList());
+        List<KeywordDto> keywordDtos = idCard.getKeywords().stream().map(KeywordDto::of).toList();
 
         return IdCardDetailsDto.of(idCard, keywordDtos);
     }

--- a/Domain/src/main/java/com/dingdong/domain/domains/community/adaptor/CommunityAdaptor.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/community/adaptor/CommunityAdaptor.java
@@ -1,12 +1,12 @@
 package com.dingdong.domain.domains.community.adaptor;
 
+import static com.dingdong.domain.domains.community.exception.CommunityErrorCode.NOT_FOUND_COMMUNITY;
+
 import com.dingdong.core.annotation.Adaptor;
 import com.dingdong.core.exception.BaseException;
 import com.dingdong.domain.domains.community.domain.Community;
 import com.dingdong.domain.domains.community.repository.CommunityRepository;
 import lombok.RequiredArgsConstructor;
-
-import static com.dingdong.domain.domains.community.exception.CommunityErrorCode.NOT_FOUND_COMMUNITY;
 
 @Adaptor
 @RequiredArgsConstructor

--- a/Domain/src/main/java/com/dingdong/domain/domains/community/adaptor/CommunityAdaptor.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/community/adaptor/CommunityAdaptor.java
@@ -1,12 +1,12 @@
 package com.dingdong.domain.domains.community.adaptor;
 
-import static com.dingdong.domain.domains.community.exception.CommunityErrorCode.NOT_FOUND_COMMUNITY;
-
 import com.dingdong.core.annotation.Adaptor;
 import com.dingdong.core.exception.BaseException;
 import com.dingdong.domain.domains.community.domain.Community;
 import com.dingdong.domain.domains.community.repository.CommunityRepository;
 import lombok.RequiredArgsConstructor;
+
+import static com.dingdong.domain.domains.community.exception.CommunityErrorCode.NOT_FOUND_COMMUNITY;
 
 @Adaptor
 @RequiredArgsConstructor
@@ -14,7 +14,7 @@ public class CommunityAdaptor {
 
     private final CommunityRepository communityRepository;
 
-    public Community find(Long communityId) {
+    public Community findById(Long communityId) {
         return communityRepository
                 .findById(communityId)
                 .orElseThrow(() -> new BaseException(NOT_FOUND_COMMUNITY));

--- a/Domain/src/main/java/com/dingdong/domain/domains/idcard/adaptor/IdCardAdaptor.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/idcard/adaptor/IdCardAdaptor.java
@@ -14,7 +14,7 @@ public class IdCardAdaptor {
 
     private final IdCardRepository idCardRepository;
 
-    public IdCard find(Long idCardId) {
+    public IdCard findById(Long idCardId) {
         return idCardRepository
                 .findById(idCardId)
                 .orElseThrow(() -> new BaseException(NOT_FOUND_ID_CARD));

--- a/Domain/src/main/java/com/dingdong/domain/domains/idcard/domain/entity/IdCard.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/idcard/domain/entity/IdCard.java
@@ -5,7 +5,6 @@ import com.dingdong.domain.domains.AbstractTimeStamp;
 import com.dingdong.domain.domains.idcard.domain.enums.CharacterType;
 import com.dingdong.domain.domains.idcard.domain.vo.Character;
 import com.dingdong.domain.domains.idcard.domain.vo.UserInfo;
-
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.CascadeType;
@@ -17,7 +16,6 @@ import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
-
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -32,11 +30,9 @@ public class IdCard extends AbstractTimeStamp {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @NotNull
-    private Long communityId;
+    @NotNull private Long communityId;
 
-    @Embedded
-    private UserInfo userInfo;
+    @Embedded private UserInfo userInfo;
 
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Keyword> keywords = new ArrayList<>();

--- a/Domain/src/main/java/com/dingdong/domain/domains/idcard/domain/entity/IdCard.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/idcard/domain/entity/IdCard.java
@@ -2,8 +2,10 @@ package com.dingdong.domain.domains.idcard.domain.entity;
 
 
 import com.dingdong.domain.domains.AbstractTimeStamp;
+import com.dingdong.domain.domains.idcard.domain.enums.CharacterType;
 import com.dingdong.domain.domains.idcard.domain.vo.Character;
 import com.dingdong.domain.domains.idcard.domain.vo.UserInfo;
+
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.CascadeType;
@@ -15,6 +17,7 @@ import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
+
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -29,9 +32,11 @@ public class IdCard extends AbstractTimeStamp {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @NotNull private Long communityId;
+    @NotNull
+    private Long communityId;
 
-    @Embedded private UserInfo userInfo;
+    @Embedded
+    private UserInfo userInfo;
 
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Keyword> keywords = new ArrayList<>();
@@ -58,5 +63,21 @@ public class IdCard extends AbstractTimeStamp {
 
     public void updateKeywords(List<Keyword> keywords) {
         this.keywords = keywords;
+    }
+
+    public String getNickname() {
+        return this.userInfo.getNickname();
+    }
+
+    public String getProfileImageUrl() {
+        return this.userInfo.getProfileImageUrl();
+    }
+
+    public String getAboutMe() {
+        return this.getUserInfo().getAboutMe();
+    }
+
+    public CharacterType getCharacterType() {
+        return this.userInfo.getCharacter().getCharacterType();
     }
 }

--- a/Domain/src/main/java/com/dingdong/domain/domains/idcard/domain/enums/CharacterType.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/idcard/domain/enums/CharacterType.java
@@ -1,25 +1,12 @@
 package com.dingdong.domain.domains.idcard.domain.enums;
 
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public enum CharacterType {
-    PIPI("FIRST", "피피", "Pipi"),
-    LUNA("FIRST", "루나", "Luna");
-
-    final String group;
-    final String korean;
-    final String english;
-
-    public static List<CharacterType> getCharacterByGroupNumber(String groupNumber) {
-        return Arrays.stream(values())
-                .filter(characterType -> characterType.getGroup().equals(groupNumber))
-                .collect(Collectors.toList());
-    }
+    BUDDY,
+    TOBY,
+    PIPI,
+    TRUE;
 }

--- a/Domain/src/main/java/com/dingdong/domain/domains/idcard/domain/vo/UserInfo.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/idcard/domain/vo/UserInfo.java
@@ -4,6 +4,7 @@ package com.dingdong.domain.domains.idcard.domain.vo;
 import javax.persistence.Embeddable;
 import javax.persistence.Embedded;
 import javax.validation.constraints.NotNull;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,15 +12,20 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class UserInfo {
-    @NotNull private Long userId;
+    @NotNull
+    private Long userId;
 
     private String profileImageUrl;
 
-    @NotNull private String nickname;
+    @NotNull
+    private String nickname;
 
-    @NotNull private String aboutMe;
+    @NotNull
+    private String aboutMe;
 
-    @Embedded @NotNull private Character character;
+    @Embedded
+    @NotNull
+    private Character character;
 
     private UserInfo(
             Long userId,

--- a/Domain/src/main/java/com/dingdong/domain/domains/idcard/domain/vo/UserInfo.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/idcard/domain/vo/UserInfo.java
@@ -4,7 +4,6 @@ package com.dingdong.domain.domains.idcard.domain.vo;
 import javax.persistence.Embeddable;
 import javax.persistence.Embedded;
 import javax.validation.constraints.NotNull;
-
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -12,20 +11,15 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class UserInfo {
-    @NotNull
-    private Long userId;
+    @NotNull private Long userId;
 
     private String profileImageUrl;
 
-    @NotNull
-    private String nickname;
+    @NotNull private String nickname;
 
-    @NotNull
-    private String aboutMe;
+    @NotNull private String aboutMe;
 
-    @Embedded
-    @NotNull
-    private Character character;
+    @Embedded @NotNull private Character character;
 
     private UserInfo(
             Long userId,


### PR DESCRIPTION
## 개요
- [DEP-82: 주민증 상세 조회 API 구현](https://darae0730.atlassian.net/jira/software/c/projects/DEP/issues/DEP-82?filter=allissues)

## 작업사항
<img width="273" alt="image" src="https://github.com/depromeet/Ding-dong-BE/assets/74492426/9ee8be76-89b5-402b-b36f-0f666b37dd2a">

주민증 상세 조회 기능 구현

## 변경로직
- 서비스 클래스 하나로 통합
- 불필요한 주석 제거