### PR TITLE
DEP-158: 새알림 여부 및 읽음처리 API

### DIFF
--- a/Api/src/main/java/com/dingdong/api/notification/controller/NotificationController.java
+++ b/Api/src/main/java/com/dingdong/api/notification/controller/NotificationController.java
@@ -35,11 +35,19 @@ public class NotificationController {
 
     @Operation(summary = "알림 읽음 처리")
     @PutMapping("/{notificationId}/read")
-    public void readNotification(@PathVariable Long notificationId) {}
+    public void readNotification(@PathVariable Long notificationId) {
+        notificationService.readNotification(notificationId);
+    }
 
     @Operation(summary = "알림 목록 조회")
     @GetMapping
     public SliceResponse<NotificationDto> getNotifications(@PageableDefault Pageable pageable) {
         return SliceResponse.from(notificationService.getNotifications(pageable));
+    }
+
+    @Operation(summary = "미확인 알림 존재 여부")
+    @GetMapping("/unread")
+    public boolean existsUnreadNotifications() {
+        return notificationService.existsUnreadNotifications();
     }
 }

--- a/Domain/src/main/java/com/dingdong/domain/domains/notification/adaptor/NotificationAdaptor.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/notification/adaptor/NotificationAdaptor.java
@@ -1,0 +1,34 @@
+package com.dingdong.domain.domains.notification.adaptor;
+
+import static com.dingdong.domain.domains.notification.exception.NotificationErrorCode.NOT_FOUND_NOTIFICATION;
+
+import com.dingdong.core.annotation.Adaptor;
+import com.dingdong.core.exception.BaseException;
+import com.dingdong.domain.domains.notification.domain.entity.Notification;
+import com.dingdong.domain.domains.notification.domain.enums.NotificationStatus;
+import com.dingdong.domain.domains.notification.domain.vo.NotificationVO;
+import com.dingdong.domain.domains.notification.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+
+@Adaptor
+@RequiredArgsConstructor
+public class NotificationAdaptor {
+    private final NotificationRepository notificationRepository;
+
+    public Slice<NotificationVO> findNotificationByConditionInPage(Long userId, Pageable pageable) {
+        return notificationRepository.findNotificationByConditionInPage(userId, pageable);
+    }
+
+    public Notification findById(Long notificationId) {
+        return notificationRepository
+                .findById(notificationId)
+                .orElseThrow(() -> new BaseException(NOT_FOUND_NOTIFICATION));
+    }
+
+    public boolean existsUnreadNotifications(Long userId) {
+        return notificationRepository.existsByUserIdAndNotificationStatus(
+                userId, NotificationStatus.UNREAD);
+    }
+}

--- a/Domain/src/main/java/com/dingdong/domain/domains/notification/domain/entity/Notification.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/notification/domain/entity/Notification.java
@@ -1,6 +1,8 @@
 package com.dingdong.domain.domains.notification.domain.entity;
 
+import static com.dingdong.domain.domains.notification.exception.NotificationErrorCode.NO_AUTHORITY_UPDATE_NOTIFICATION;
 
+import com.dingdong.core.exception.BaseException;
 import com.dingdong.domain.domains.AbstractTimeStamp;
 import com.dingdong.domain.domains.notification.domain.enums.NotificationStatus;
 import com.dingdong.domain.domains.notification.domain.enums.NotificationType;
@@ -39,4 +41,11 @@ public class Notification extends AbstractTimeStamp {
     @Enumerated(EnumType.STRING)
     @NotNull
     private NotificationStatus notificationStatus;
+
+    public void read(Long userId) {
+        if (this.userId != userId) {
+            throw new BaseException(NO_AUTHORITY_UPDATE_NOTIFICATION);
+        }
+        this.notificationStatus = NotificationStatus.READ;
+    }
 }

--- a/Domain/src/main/java/com/dingdong/domain/domains/notification/exception/NotificationErrorCode.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/notification/exception/NotificationErrorCode.java
@@ -1,0 +1,37 @@
+package com.dingdong.domain.domains.notification.exception;
+
+import static com.dingdong.core.consts.StaticVal.NOT_FOUND;
+
+import com.dingdong.core.annotation.ExplainError;
+import com.dingdong.core.dto.ErrorDetail;
+import com.dingdong.core.exception.BaseErrorCode;
+import java.lang.reflect.Field;
+import java.util.Objects;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum NotificationErrorCode implements BaseErrorCode {
+    @ExplainError("존재하지 않는 알림을 조회했을 경우 발생하는 오류입니다.")
+    NOT_FOUND_NOTIFICATION(NOT_FOUND, "Notification-404-1", "존재하지 않는 알림입니다."),
+
+    @ExplainError("알림 수정 권한이 없을때 발생하는 오류입니다.")
+    NO_AUTHORITY_UPDATE_NOTIFICATION(403, "Notification-403-1", "알림 수정 권한이 없습니다.");
+
+    private final Integer statusCode;
+    private final String errorCode;
+    private final String reason;
+
+    @Override
+    public ErrorDetail getErrorDetail() {
+        return ErrorDetail.of(statusCode, errorCode, reason);
+    }
+
+    @Override
+    public String getExplainError() throws NoSuchFieldException {
+        Field field = this.getClass().getField(this.name());
+        ExplainError annotation = field.getAnnotation(ExplainError.class);
+        return Objects.nonNull(annotation) ? annotation.value() : this.getReason();
+    }
+}

--- a/Domain/src/main/java/com/dingdong/domain/domains/notification/repository/NotificationRepository.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/notification/repository/NotificationRepository.java
@@ -2,7 +2,10 @@ package com.dingdong.domain.domains.notification.repository;
 
 
 import com.dingdong.domain.domains.notification.domain.entity.Notification;
+import com.dingdong.domain.domains.notification.domain.enums.NotificationStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository
-        extends JpaRepository<Notification, Long>, NotificationRepositoryExtension {}
+        extends JpaRepository<Notification, Long>, NotificationRepositoryExtension {
+    boolean existsByUserIdAndNotificationStatus(Long userId, NotificationStatus notificationStatus);
+}


### PR DESCRIPTION
## 개요
- [DEP-158: 새알림 여부 및 읽음처리 API](https://darae0730.atlassian.net/jira/software/c/projects/DEP/issues/DEP-158?filter=allissues)

## 작업사항
- 새 알림 여부 및 읽음 처리 API를 작업했어용
- https://github.com/depromeet/Ding-dong-BE/pull/40
- 위 branch에서 따와서 작업한 거라 보기 편하라고 feat/DEP-158 -> feat/DEP-155로 보내놨고, 위에 꺼 머지 되면 feat/DEP-158 -> dev로 바꿀께용

## 변경 or 주요 로직
- Notification Service에서 Repository를 바라보는게 아닌 Adaptor를 바라보도록 변경했어용
- 이하 코멘트 확인