### PR TITLE
DEP-148: 행성 가입 및 떠나기 관련 API 작업

### DIFF
--- a/Api/src/main/java/com/dingdong/api/community/controller/CommunityController.java
+++ b/Api/src/main/java/com/dingdong/api/community/controller/CommunityController.java
@@ -2,6 +2,7 @@ package com.dingdong.api.community.controller;
 
 
 import com.dingdong.api.community.controller.request.CreateCommunityRequest;
+import com.dingdong.api.community.controller.request.JoinCommunityRequest;
 import com.dingdong.api.community.controller.request.UpdateCommunityRequest;
 import com.dingdong.api.community.controller.response.CommunityDetailsResponse;
 import com.dingdong.api.community.controller.response.CommunityListResponse;
@@ -77,5 +78,11 @@ public class CommunityController {
     @GetMapping("validate")
     public IdResponse validateInvitationCode(@RequestParam String code) {
         return IdResponse.from(communityService.validateInvitationCode(code));
+    }
+
+    @Operation(summary = "행성 가입하기")
+    @PostMapping("/join")
+    public void joinCommunity(@RequestBody JoinCommunityRequest request) {
+        communityService.joinCommunity(request);
     }
 }

--- a/Api/src/main/java/com/dingdong/api/community/controller/CommunityController.java
+++ b/Api/src/main/java/com/dingdong/api/community/controller/CommunityController.java
@@ -85,4 +85,10 @@ public class CommunityController {
     public void joinCommunity(@RequestBody JoinCommunityRequest request) {
         communityService.joinCommunity(request);
     }
+
+    @Operation(summary = "행성 떠나기")
+    @GetMapping("/leave/{communityId}")
+    public void leaveCommunity(@PathVariable Long communityId) {
+        communityService.leaveCommunity(communityId);
+    }
 }

--- a/Api/src/main/java/com/dingdong/api/community/controller/CommunityController.java
+++ b/Api/src/main/java/com/dingdong/api/community/controller/CommunityController.java
@@ -72,4 +72,10 @@ public class CommunityController {
     public boolean checkDuplicatedName(@RequestParam String name) {
         return communityService.checkDuplicatedName(name);
     }
+
+    @Operation(summary = "행성 초대 코드 검사 (유효한 초대코드일 경우 : 행성 ID 응답 / 유효하지 않을 경우 : Error)")
+    @GetMapping("validate")
+    public IdResponse validateInvitationCode(@RequestParam String code) {
+        return IdResponse.from(communityService.validateInvitationCode(code));
+    }
 }

--- a/Api/src/main/java/com/dingdong/api/community/controller/CommunityController.java
+++ b/Api/src/main/java/com/dingdong/api/community/controller/CommunityController.java
@@ -75,19 +75,19 @@ public class CommunityController {
     }
 
     @Operation(summary = "행성 초대 코드 검사 (유효한 초대코드일 경우 : 행성 ID 응답 / 유효하지 않을 경우 : Error)")
-    @GetMapping("validate")
+    @GetMapping("/validate")
     public IdResponse validateInvitationCode(@RequestParam String code) {
         return IdResponse.from(communityService.validateInvitationCode(code));
     }
 
     @Operation(summary = "행성 가입하기")
     @PostMapping("/join")
-    public void joinCommunity(@RequestBody JoinCommunityRequest request) {
+    public void joinCommunity(@RequestBody @Valid JoinCommunityRequest request) {
         communityService.joinCommunity(request);
     }
 
     @Operation(summary = "행성 떠나기")
-    @GetMapping("/leave/{communityId}")
+    @PutMapping("/{communityId}/leave")
     public void leaveCommunity(@PathVariable Long communityId) {
         communityService.leaveCommunity(communityId);
     }

--- a/Api/src/main/java/com/dingdong/api/community/controller/CommunityController.java
+++ b/Api/src/main/java/com/dingdong/api/community/controller/CommunityController.java
@@ -87,8 +87,8 @@ public class CommunityController {
     }
 
     @Operation(summary = "행성 떠나기")
-    @PutMapping("/{communityId}/leave")
-    public void leaveCommunity(@PathVariable Long communityId) {
-        communityService.leaveCommunity(communityId);
+    @PutMapping("/{communityId}/withdrawal")
+    public void withdrawCommunity(@PathVariable Long communityId) {
+        communityService.withdrawCommunity(communityId);
     }
 }

--- a/Api/src/main/java/com/dingdong/api/community/controller/request/JoinCommunityRequest.java
+++ b/Api/src/main/java/com/dingdong/api/community/controller/request/JoinCommunityRequest.java
@@ -1,9 +1,11 @@
 package com.dingdong.api.community.controller.request;
 
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
 public class JoinCommunityRequest {
+    @Schema(description = "가입할 행성 ID", example = "1")
     private Long communityId;
 }

--- a/Api/src/main/java/com/dingdong/api/community/controller/request/JoinCommunityRequest.java
+++ b/Api/src/main/java/com/dingdong/api/community/controller/request/JoinCommunityRequest.java
@@ -1,0 +1,9 @@
+package com.dingdong.api.community.controller.request;
+
+
+import lombok.Getter;
+
+@Getter
+public class JoinCommunityRequest {
+    private Long communityId;
+}

--- a/Api/src/main/java/com/dingdong/api/community/controller/request/JoinCommunityRequest.java
+++ b/Api/src/main/java/com/dingdong/api/community/controller/request/JoinCommunityRequest.java
@@ -2,10 +2,12 @@ package com.dingdong.api.community.controller.request;
 
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
 public class JoinCommunityRequest {
     @Schema(description = "가입할 행성 ID", example = "1")
+    @NotNull(message = "행성 ID를 입력해주세요.")
     private Long communityId;
 }

--- a/Api/src/main/java/com/dingdong/api/community/service/CommunityService.java
+++ b/Api/src/main/java/com/dingdong/api/community/service/CommunityService.java
@@ -114,11 +114,20 @@ public class CommunityService {
         return communityAdaptor.findByInvitationCode(code).getId();
     }
 
+    @Transactional
     public void joinCommunity(JoinCommunityRequest request) {
         User user = userHelper.getCurrentUser();
         Community community = communityAdaptor.findById(request.getCommunityId());
         communityValidator.isAlreadyJoinCommunity(user, community.getId());
         user.joinCommunity(community);
+    }
+
+    @Transactional
+    public void leaveCommunity(Long communityId) {
+        User user = userHelper.getCurrentUser();
+        Community community = communityAdaptor.findById(communityId);
+        communityValidator.isJoinCommunity(user, communityId);
+        user.getCommunities().remove(community);
     }
 
     private Community findAndValidateAdminUserInCommunity(Long communityId) {

--- a/Api/src/main/java/com/dingdong/api/community/service/CommunityService.java
+++ b/Api/src/main/java/com/dingdong/api/community/service/CommunityService.java
@@ -109,6 +109,10 @@ public class CommunityService {
         return communityAdaptor.isAlreadyExistCommunityName(name);
     }
 
+    public Long validateInvitationCode(String code) {
+        return communityAdaptor.findByInvitationCode(code).getId();
+    }
+
     private Community findAndValidateAdminUserInCommunity(Long communityId) {
         User currentUser = userHelper.getCurrentUser();
         communityValidator.verifyAdminUser(communityId, currentUser.getId());

--- a/Api/src/main/java/com/dingdong/api/community/service/CommunityService.java
+++ b/Api/src/main/java/com/dingdong/api/community/service/CommunityService.java
@@ -126,7 +126,7 @@ public class CommunityService {
     public void leaveCommunity(Long communityId) {
         User user = userHelper.getCurrentUser();
         Community community = communityAdaptor.findById(communityId);
-        communityValidator.isJoinCommunity(user, communityId);
+        communityValidator.isExistInCommunity(user, communityId);
         user.getCommunities().remove(community);
     }
 

--- a/Api/src/main/java/com/dingdong/api/community/service/CommunityService.java
+++ b/Api/src/main/java/com/dingdong/api/community/service/CommunityService.java
@@ -3,6 +3,7 @@ package com.dingdong.api.community.service;
 import static com.dingdong.domain.domains.idcard.exception.IdCardErrorCode.NOT_FOUND_ID_CARD;
 
 import com.dingdong.api.community.controller.request.CreateCommunityRequest;
+import com.dingdong.api.community.controller.request.JoinCommunityRequest;
 import com.dingdong.api.community.controller.request.UpdateCommunityRequest;
 import com.dingdong.api.community.dto.CommunityDetailsDto;
 import com.dingdong.api.community.dto.CommunityIdCardsDto;
@@ -111,6 +112,13 @@ public class CommunityService {
 
     public Long validateInvitationCode(String code) {
         return communityAdaptor.findByInvitationCode(code).getId();
+    }
+
+    public void joinCommunity(JoinCommunityRequest request) {
+        User user = userHelper.getCurrentUser();
+        Community community = communityAdaptor.findById(request.getCommunityId());
+        communityValidator.isAlreadyJoinCommunity(user, community.getId());
+        user.joinCommunity(community);
     }
 
     private Community findAndValidateAdminUserInCommunity(Long communityId) {

--- a/Api/src/main/java/com/dingdong/api/community/service/CommunityService.java
+++ b/Api/src/main/java/com/dingdong/api/community/service/CommunityService.java
@@ -123,7 +123,7 @@ public class CommunityService {
     }
 
     @Transactional
-    public void leaveCommunity(Long communityId) {
+    public void withdrawCommunity(Long communityId) {
         User user = userHelper.getCurrentUser();
         Community community = communityAdaptor.findById(communityId);
         communityValidator.isExistInCommunity(user, communityId);

--- a/Api/src/main/java/com/dingdong/api/user/dto/UserProfileDto.java
+++ b/Api/src/main/java/com/dingdong/api/user/dto/UserProfileDto.java
@@ -1,22 +1,43 @@
 package com.dingdong.api.user.dto;
 
 
+import com.dingdong.domain.domains.community.domain.entity.Community;
 import com.dingdong.domain.domains.idcard.domain.enums.CharacterType;
 import com.dingdong.domain.domains.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
 public class UserProfileDto {
+    @Schema(description = "사용자 ID")
     private Long userId;
+
+    @Schema(description = "사용자 이메일")
     private String email;
+
+    @Schema(description = "사용자 성별")
     private String gender;
+
+    @Schema(description = "사용자 나이대")
     private String ageRange;
+
+    @Schema(description = "사용자 프로필 이미지 Url")
     private String profileImageUrl;
+
+    @Schema(description = "사용자 캐릭터 타입")
     private CharacterType characterType;
 
-    public static UserProfileDto from(User user) {
+    @Schema(description = "사용자 캐릭터 생성 여부 (true : 캐릭터 타입 존재, false : 캐릭터 타입 null)")
+    private boolean isCharacterCreated;
+
+    @Schema(description = "사용자가 속한 행성 ID 리스트")
+    private List<Long> planetIds;
+
+    public static UserProfileDto from(User user, boolean isCharacterCreated) {
         return UserProfileDto.builder()
                 .userId(user.getId())
                 .email(user.getEmail())
@@ -24,6 +45,11 @@ public class UserProfileDto {
                 .ageRange(user.getAgeRange())
                 .profileImageUrl(null)
                 .characterType(user.getUserCharacterType())
+                .isCharacterCreated(isCharacterCreated)
+                .planetIds(
+                        user.getCommunities().stream()
+                                .map(Community::getId)
+                                .collect(Collectors.toList()))
                 .build();
     }
 }

--- a/Api/src/main/java/com/dingdong/api/user/dto/UserProfileDto.java
+++ b/Api/src/main/java/com/dingdong/api/user/dto/UserProfileDto.java
@@ -6,7 +6,6 @@ import com.dingdong.domain.domains.idcard.domain.enums.CharacterType;
 import com.dingdong.domain.domains.user.domain.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -28,16 +27,13 @@ public class UserProfileDto {
     @Schema(description = "사용자 프로필 이미지 Url")
     private String profileImageUrl;
 
-    @Schema(description = "사용자 캐릭터 타입")
+    @Schema(description = "사용자 캐릭터 타입 (캐릭터 이름 : 생성한 캐릭터 타입, null : 캐릭터를 생성하지 않은 경우)")
     private CharacterType characterType;
 
-    @Schema(description = "사용자 캐릭터 생성 여부 (true : 캐릭터 타입 존재, false : 캐릭터 타입 null)")
-    private boolean isCharacterCreated;
-
     @Schema(description = "사용자가 속한 행성 ID 리스트")
-    private List<Long> planetIds;
+    private List<Long> communityIds;
 
-    public static UserProfileDto from(User user, boolean isCharacterCreated) {
+    public static UserProfileDto from(User user) {
         return UserProfileDto.builder()
                 .userId(user.getId())
                 .email(user.getEmail())
@@ -45,11 +41,7 @@ public class UserProfileDto {
                 .ageRange(user.getAgeRange())
                 .profileImageUrl(null)
                 .characterType(user.getUserCharacterType())
-                .isCharacterCreated(isCharacterCreated)
-                .planetIds(
-                        user.getCommunities().stream()
-                                .map(Community::getId)
-                                .collect(Collectors.toList()))
+                .communityIds(user.getCommunities().stream().map(Community::getId).toList())
                 .build();
     }
 }

--- a/Api/src/main/java/com/dingdong/api/user/service/UserService.java
+++ b/Api/src/main/java/com/dingdong/api/user/service/UserService.java
@@ -6,6 +6,7 @@ import com.dingdong.api.global.helper.UserHelper;
 import com.dingdong.api.user.controller.request.UserCharacterRequest;
 import com.dingdong.api.user.dto.UserProfileDto;
 import com.dingdong.domain.domains.idcard.domain.model.Character;
+import com.dingdong.domain.domains.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -20,7 +21,8 @@ public class UserService {
     private final UserHelper userHelper;
 
     public UserProfileDto getUserProfile() {
-        return UserProfileDto.from(userHelper.getCurrentUser());
+        User user = userHelper.getCurrentUser();
+        return UserProfileDto.from(user, user.getCharacter() != null);
     }
 
     @Transactional

--- a/Api/src/main/java/com/dingdong/api/user/service/UserService.java
+++ b/Api/src/main/java/com/dingdong/api/user/service/UserService.java
@@ -6,7 +6,6 @@ import com.dingdong.api.global.helper.UserHelper;
 import com.dingdong.api.user.controller.request.UserCharacterRequest;
 import com.dingdong.api.user.dto.UserProfileDto;
 import com.dingdong.domain.domains.idcard.domain.model.Character;
-import com.dingdong.domain.domains.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -21,8 +20,7 @@ public class UserService {
     private final UserHelper userHelper;
 
     public UserProfileDto getUserProfile() {
-        User user = userHelper.getCurrentUser();
-        return UserProfileDto.from(user, user.getCharacter() != null);
+        return UserProfileDto.from(userHelper.getCurrentUser());
     }
 
     @Transactional

--- a/Core/src/main/java/com/dingdong/core/consts/StaticVal.java
+++ b/Core/src/main/java/com/dingdong/core/consts/StaticVal.java
@@ -11,6 +11,7 @@ public class StaticVal {
     public static final String BEARER = "Bearer ";
 
     public static final Integer OK = 200;
+    public static final Integer REDIRECTION = 300;
     /*
     에러 코드 관련 static 변수들
      */

--- a/Domain/src/main/java/com/dingdong/domain/domains/community/adaptor/CommunityAdaptor.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/community/adaptor/CommunityAdaptor.java
@@ -47,4 +47,10 @@ public class CommunityAdaptor {
     public boolean isAlreadyExistCommunityName(String name) {
         return communityRepository.existsCommunityByName(name);
     }
+
+    public Community findByInvitationCode(String code) {
+        return communityRepository
+                .findByInvitationCode(code)
+                .orElseThrow(() -> new BaseException(NOT_FOUND_COMMUNITY));
+    }
 }

--- a/Domain/src/main/java/com/dingdong/domain/domains/community/exception/CommunityErrorCode.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/community/exception/CommunityErrorCode.java
@@ -22,7 +22,11 @@ public enum CommunityErrorCode implements BaseErrorCode {
     @ExplainError("행성 이름이 최소 길이인 1글자 미만일 때 발생하는 오류입니다.")
     MIN_LIMIT_COMMUNITY_NAME(BAD_REQUEST, "Community-400-2", "행성 이름 최소 길이는 1글자입니다."),
     @ExplainError("행성 이름이 최대 길이인 16글자를 초과할 때 발생하는 오류입니다.")
-    MAX_LIMIT_COMMUNITY_NAME(BAD_REQUEST, "Community-400-3", "행성 이름 최대 길이는 16글자입니다.");
+    MAX_LIMIT_COMMUNITY_NAME(BAD_REQUEST, "Community-400-3", "행성 이름 최대 길이는 16글자입니다."),
+    @ExplainError("이미 가입된 행성에 가입 시도를 할 때 발생하는 오류입니다.")
+    ALREADY_JOIN_COMMUNITY(REDIRECTION, "Community-300-1", "이미 가입된 행성입니다."),
+    @ExplainError("가입하지 않은 행성에서 행성 떠나기를 시도할 때 발샐하는 오류입니다.")
+    NOT_JOIN_COMMUNITY(BAD_REQUEST, "Community-400-4", "가입하지 않은 행성입니다.");
 
     private final Integer statusCode;
     private final String errorCode;

--- a/Domain/src/main/java/com/dingdong/domain/domains/community/exception/CommunityErrorCode.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/community/exception/CommunityErrorCode.java
@@ -25,7 +25,7 @@ public enum CommunityErrorCode implements BaseErrorCode {
     MAX_LIMIT_COMMUNITY_NAME(BAD_REQUEST, "Community-400-3", "행성 이름 최대 길이는 16글자입니다."),
     @ExplainError("이미 가입된 행성에 가입 시도를 할 때 발생하는 오류입니다.")
     ALREADY_JOIN_COMMUNITY(REDIRECTION, "Community-300-1", "이미 가입된 행성입니다."),
-    @ExplainError("가입하지 않은 행성에서 행성 떠나기를 시도할 때 발샐하는 오류입니다.")
+    @ExplainError("가입하지 않은 행성에서 행성 떠나기를 시도할 때 발생하는 오류입니다.")
     NOT_JOIN_COMMUNITY(BAD_REQUEST, "Community-400-4", "가입하지 않은 행성입니다.");
 
     private final Integer statusCode;

--- a/Domain/src/main/java/com/dingdong/domain/domains/community/repository/CommunityRepository.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/community/repository/CommunityRepository.java
@@ -2,6 +2,7 @@ package com.dingdong.domain.domains.community.repository;
 
 
 import com.dingdong.domain.domains.community.domain.entity.Community;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,4 +11,6 @@ public interface CommunityRepository extends JpaRepository<Community, Long> {
     boolean existsCommunityByInvitationCode(String invitationCode);
 
     boolean existsCommunityByName(String name);
+
+    Optional<Community> findByInvitationCode(String invitationCode);
 }

--- a/Domain/src/main/java/com/dingdong/domain/domains/community/validator/CommunityValidator.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/community/validator/CommunityValidator.java
@@ -46,4 +46,10 @@ public class CommunityValidator {
             throw new BaseException(ALREADY_JOIN_COMMUNITY);
         }
     }
+
+    public void isJoinCommunity(User user, Long communityId) {
+        if (user.getCommunities().stream().noneMatch(c -> c.getId().equals(communityId))) {
+            throw new BaseException(NOT_JOIN_COMMUNITY);
+        }
+    }
 }

--- a/Domain/src/main/java/com/dingdong/domain/domains/community/validator/CommunityValidator.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/community/validator/CommunityValidator.java
@@ -47,7 +47,7 @@ public class CommunityValidator {
         }
     }
 
-    public void isJoinCommunity(User user, Long communityId) {
+    public void isExistInCommunity(User user, Long communityId) {
         if (user.getCommunities().stream().noneMatch(c -> c.getId().equals(communityId))) {
             throw new BaseException(NOT_JOIN_COMMUNITY);
         }

--- a/Domain/src/main/java/com/dingdong/domain/domains/community/validator/CommunityValidator.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/community/validator/CommunityValidator.java
@@ -1,12 +1,12 @@
 package com.dingdong.domain.domains.community.validator;
 
-import static com.dingdong.domain.domains.community.exception.CommunityErrorCode.MAX_LIMIT_COMMUNITY_NAME;
-import static com.dingdong.domain.domains.community.exception.CommunityErrorCode.MIN_LIMIT_COMMUNITY_NAME;
+import static com.dingdong.domain.domains.community.exception.CommunityErrorCode.*;
 
 import com.dingdong.core.annotation.Validator;
 import com.dingdong.core.exception.BaseException;
 import com.dingdong.domain.domains.community.adaptor.CommunityAdaptor;
 import com.dingdong.domain.domains.community.exception.CommunityErrorCode;
+import com.dingdong.domain.domains.user.domain.User;
 import lombok.RequiredArgsConstructor;
 
 @Validator
@@ -39,5 +39,11 @@ public class CommunityValidator {
     public void validateCommunityNameSize(String name) {
         if (name.length() < 1) throw new BaseException(MIN_LIMIT_COMMUNITY_NAME);
         if (name.length() > 16) throw new BaseException(MAX_LIMIT_COMMUNITY_NAME);
+    }
+
+    public void isAlreadyJoinCommunity(User user, Long communityId) {
+        if (user.getCommunities().stream().anyMatch(c -> c.getId().equals(communityId))) {
+            throw new BaseException(ALREADY_JOIN_COMMUNITY);
+        }
     }
 }


### PR DESCRIPTION
## 개요
- [DEP-148](https://darae0730.atlassian.net/browse/DEP-148) 의 하위 이슈에 해당하는 API 작업 진행
- 한 번에 올린다고 브랜치는 feat/DEP-160 에서 진행되었습니닷^~^

## 작업사항
- 행성 코드로 행성 조회
- 행성 가입하기
<img width="1257" alt="스크린샷 2023-06-29 오전 3 20 03" src="https://github.com/depromeet/Ding-dong-BE/assets/80315847/c93b5e5c-b731-420a-b215-a080513eaa20">

- 행성 떠나기
- 유저 프로필 정보 조회 필드 추가 ([추가 요청 스레드](https://depromeet13th.slack.com/archives/C0515CGG9H8/p1687879728375699))
  - 캐릭터 생성 여부
  - 가입한 행성 ID 목록

## 변경로직
- 행성 가입 과정에서, 초대 링크를 통해 연결된 행성에 이미 가입된 경우는 Error 케이스는 아니라고 판단해 400이나 500번대 에러가 아닌 별도 에러 코드로 응답해달라고 요청주셔서 300번대 에러코드로 하나 추가했습니닷