### PR TITLE
DEP-175: 이벤트 발행으로 알림 발송

### DIFF
--- a/Api/src/main/java/com/dingdong/DingdongApiApplication.java
+++ b/Api/src/main/java/com/dingdong/DingdongApiApplication.java
@@ -12,6 +12,7 @@ import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.env.Environment;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @EnableFeignClients
 @EntityScan("com.dingdong.domain")
@@ -25,6 +26,7 @@ import org.springframework.core.env.Environment;
                     .ContextRegionProviderAutoConfiguration.class
         })
 @Slf4j
+@EnableAsync
 public class DingdongApiApplication implements ApplicationListener<ApplicationReadyEvent> {
 
     private final Environment environment;

--- a/Api/src/main/java/com/dingdong/api/global/event/EventListener.java
+++ b/Api/src/main/java/com/dingdong/api/global/event/EventListener.java
@@ -1,0 +1,22 @@
+package com.dingdong.api.global.event;
+
+
+import com.dingdong.api.notification.service.NotificationService;
+import com.dingdong.domain.domains.notification.domain.entity.Notification;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class EventListener {
+    private final NotificationService notificationService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    public void notify(Notification notification) {
+        notificationService.notify(notification.getUserId(), true);
+    }
+}

--- a/Api/src/main/java/com/dingdong/api/idcard/service/CommentService.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/service/CommentService.java
@@ -117,7 +117,7 @@ public class CommentService {
 
         notificationService.createAndPublishNotification(
                 getNotificationTargetUserId(comment),
-                NotificationType.COMMENT_REPLY,
+                NotificationType.COMMENT_LIKE,
                 NotificationContent.create(
                         idCard.getCommunityId(), currentUser.getId(), comment.getId()));
 
@@ -137,7 +137,7 @@ public class CommentService {
 
         notificationService.createAndPublishNotification(
                 getNotificationTargetUserId(commentReply),
-                NotificationType.COMMENT_REPLY,
+                NotificationType.COMMENT_LIKE,
                 NotificationContent.create(
                         idCard.getCommunityId(), currentUser.getId(), commentReply.getId()));
 

--- a/Api/src/main/java/com/dingdong/api/idcard/service/CommentService.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/service/CommentService.java
@@ -4,6 +4,7 @@ package com.dingdong.api.idcard.service;
 import com.dingdong.api.global.helper.UserHelper;
 import com.dingdong.api.idcard.controller.request.CreateCommentRequest;
 import com.dingdong.api.idcard.dto.CommentDto;
+import com.dingdong.api.notification.service.NotificationService;
 import com.dingdong.domain.common.util.SliceUtil;
 import com.dingdong.domain.domains.idcard.adaptor.CommentAdaptor;
 import com.dingdong.domain.domains.idcard.adaptor.IdCardAdaptor;
@@ -15,6 +16,8 @@ import com.dingdong.domain.domains.idcard.domain.entity.IdCard;
 import com.dingdong.domain.domains.idcard.domain.model.CommentVo;
 import com.dingdong.domain.domains.idcard.validator.CommentValidator;
 import com.dingdong.domain.domains.idcard.validator.IdCardValidator;
+import com.dingdong.domain.domains.notification.domain.enums.NotificationType;
+import com.dingdong.domain.domains.notification.domain.model.NotificationContent;
 import com.dingdong.domain.domains.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -37,6 +40,8 @@ public class CommentService {
 
     private final CommentValidator commentValidator;
 
+    private final NotificationService notificationService;
+
     /** 댓글 생성 */
     @Transactional
     public Long createComment(Long idCardId, CreateCommentRequest request) {
@@ -45,7 +50,16 @@ public class CommentService {
         IdCard idCard = idCardAdaptor.findById(idCardId);
 
         Comment comment =
-                Comment.toEntity(idCard.getId(), currentUser.getId(), request.getContents());
+                Comment.toEntity(
+                        idCard.getUserInfo().getUserId(),
+                        currentUser.getId(),
+                        request.getContents());
+
+        notificationService.createAndPublishNotification(
+                getNotificationTargetUserId(idCard),
+                NotificationType.ID_CARD_COMMENT,
+                NotificationContent.create(
+                        idCard.getCommunityId(), currentUser.getId(), comment.getId()));
 
         return commentAdaptor.save(comment).getId();
     }
@@ -54,12 +68,18 @@ public class CommentService {
     @Transactional
     public void createCommentReply(Long idCardId, Long commentId, CreateCommentRequest request) {
         User currentUser = userHelper.getCurrentUser();
-
+        IdCard idCard = idCardAdaptor.findById(idCardId);
         Comment comment = getComment(idCardId, commentId);
 
         CommentReply commentReply =
                 CommentReply.toEntity(
                         idCardId, comment.getId(), currentUser.getId(), request.getContents());
+
+        notificationService.createAndPublishNotification(
+                getNotificationTargetUserId(comment),
+                NotificationType.COMMENT_REPLY,
+                NotificationContent.create(
+                        idCard.getCommunityId(), currentUser.getId(), commentReply.getId()));
 
         comment.updateReplies(commentReply);
     }
@@ -93,6 +113,14 @@ public class CommentService {
 
         commentValidator.isExistCommentLike(comment, currentUser.getId());
 
+        IdCard idCard = idCardAdaptor.findById(idCardId);
+
+        notificationService.createAndPublishNotification(
+                getNotificationTargetUserId(comment),
+                NotificationType.COMMENT_REPLY,
+                NotificationContent.create(
+                        idCard.getCommunityId(), currentUser.getId(), comment.getId()));
+
         comment.updateLikes(CommentLike.toEntity(comment.getId(), currentUser.getId()));
     }
 
@@ -104,6 +132,14 @@ public class CommentService {
         CommentReply commentReply = getCommentReply(idCardId, commentId, commentReplyId);
 
         commentValidator.isExistCommentReplyLike(commentReply, currentUser.getId());
+
+        IdCard idCard = idCardAdaptor.findById(idCardId);
+
+        notificationService.createAndPublishNotification(
+                getNotificationTargetUserId(commentReply),
+                NotificationType.COMMENT_REPLY,
+                NotificationContent.create(
+                        idCard.getCommunityId(), currentUser.getId(), commentReply.getId()));
 
         commentReply.updateReplyLikes(
                 CommentReplyLike.toEntity(commentReplyId, currentUser.getId()));
@@ -181,5 +217,19 @@ public class CommentService {
         commentValidator.isValidCommentReply(commentReply, comment.getId());
 
         return commentReply;
+    }
+
+    private Long getNotificationTargetUserId(IdCard idCard) {
+        return idCard.getUserInfo().getUserId();
+    }
+
+    private Long getNotificationTargetUserId(Comment comment) {
+        IdCard idCard = idCardAdaptor.findById(comment.getIdCardId());
+        return idCard.getUserInfo().getUserId();
+    }
+
+    private Long getNotificationTargetUserId(CommentReply commentReply) {
+        Comment comment = commentAdaptor.findById(commentReply.getId());
+        return comment.getUserId();
     }
 }

--- a/Api/src/main/java/com/dingdong/api/notification/service/NotificationService.java
+++ b/Api/src/main/java/com/dingdong/api/notification/service/NotificationService.java
@@ -6,10 +6,13 @@ import com.dingdong.api.notification.dto.NotificationDto;
 import com.dingdong.domain.common.util.SliceUtil;
 import com.dingdong.domain.domains.notification.adaptor.NotificationAdaptor;
 import com.dingdong.domain.domains.notification.domain.entity.Notification;
+import com.dingdong.domain.domains.notification.domain.enums.NotificationType;
+import com.dingdong.domain.domains.notification.domain.model.NotificationContent;
 import com.dingdong.domain.domains.notification.domain.vo.NotificationVO;
 import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -25,6 +28,7 @@ public class NotificationService {
     private final EmitterRepository emitterRepository;
     private final UserHelper userHelper;
     private final NotificationAdaptor notificationAdaptor;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     /** 클라이언트가 구독을 위해 호출하는 메서드. */
     public SseEmitter subscribe() {
@@ -35,12 +39,6 @@ public class NotificationService {
         return emitter;
     }
 
-    /**
-     * 서버의 이벤트를 클라이언트에게 보내는 메서드 다른 서비스 로직에서 이 메서드를 사용해 데이터를 Object event에 넣고 전송하면 된다.
-     *
-     * @param userId - 메세지를 전송할 사용자의 아이디.
-     * @param event - 전송할 이벤트 객체.
-     */
     public void notify(Long userId, Object event) {
         sendNotification(userId, event);
     }
@@ -55,7 +53,7 @@ public class NotificationService {
         SseEmitter emitter = emitterRepository.get(id);
         if (emitter != null) {
             try {
-                emitter.send(SseEmitter.event().id(String.valueOf(id)).data(data));
+                emitter.send(SseEmitter.event().id(String.valueOf(id)).name("sse").data(data));
             } catch (IOException exception) {
                 emitterRepository.deleteById(id);
                 emitter.completeWithError(exception);
@@ -105,5 +103,13 @@ public class NotificationService {
         Long userId = userHelper.getCurrentUserId();
 
         return notificationAdaptor.existsUnreadNotifications(userId);
+    }
+
+    @Transactional
+    public void createAndPublishNotification(
+            Long userId, NotificationType type, NotificationContent content) {
+        Notification notification = Notification.create(userId, type, content);
+        notificationAdaptor.save(notification);
+        applicationEventPublisher.publishEvent(notification);
     }
 }

--- a/Domain/src/main/java/com/dingdong/domain/domains/notification/adaptor/NotificationAdaptor.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/notification/adaptor/NotificationAdaptor.java
@@ -31,4 +31,8 @@ public class NotificationAdaptor {
         return notificationRepository.existsByUserIdAndNotificationStatus(
                 userId, NotificationStatus.UNREAD);
     }
+
+    public void save(Notification notification) {
+        notificationRepository.save(notification);
+    }
 }

--- a/Domain/src/main/java/com/dingdong/domain/domains/notification/domain/entity/Notification.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/notification/domain/entity/Notification.java
@@ -40,12 +40,32 @@ public class Notification extends AbstractTimeStamp {
 
     @Enumerated(EnumType.STRING)
     @NotNull
-    private NotificationStatus notificationStatus;
+    private NotificationStatus notificationStatus = NotificationStatus.UNREAD;
 
     public void read(Long userId) {
         if (this.userId != userId) {
             throw new BaseException(NO_AUTHORITY_UPDATE_NOTIFICATION);
         }
         this.notificationStatus = NotificationStatus.READ;
+    }
+
+    private Notification(
+            Long userId, NotificationType notificationType, NotificationContent content) {
+        this.userId = userId;
+        this.notificationType = notificationType;
+        this.content = content;
+    }
+
+    public static Notification create(
+            Long userId,
+            NotificationType notificationType,
+            NotificationContent notificationContent) {
+        return new Notification(
+                userId,
+                notificationType,
+                NotificationContent.create(
+                        notificationContent.getCommunityId(),
+                        notificationContent.getFromUserId(),
+                        notificationContent.getCommentId()));
     }
 }

--- a/Domain/src/main/java/com/dingdong/domain/domains/notification/domain/model/NotificationContent.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/notification/domain/model/NotificationContent.java
@@ -2,16 +2,27 @@ package com.dingdong.domain.domains.notification.domain.model;
 
 
 import javax.persistence.Embeddable;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NotificationContent {
     private Long communityId;
 
     private Long fromUserId;
 
     private Long commentId;
+
+    private NotificationContent(Long communityId, Long fromUserId, Long commentId) {
+        this.communityId = communityId;
+        this.fromUserId = fromUserId;
+        this.commentId = commentId;
+    }
+
+    public static NotificationContent create(Long communityId, Long fromUserId, Long commentId) {
+        return new NotificationContent(communityId, fromUserId, commentId);
+    }
 }


### PR DESCRIPTION
## 개요
- [DEP-175: 이벤트 발행으로 알림 발송](https://darae0730.atlassian.net/browse/DEP-175)

## 작업사항
- 알림이 생성되어야 하는 부분에 알림 저장로직을 추가했어요(댓글, 대댓글의 생성 및 좋아요)

## 주요로직
옵저버 패턴중 하나인 스프링 이벤트 기능을 사용해보았습니다.

이벤트를 발생시키는 Publisher와 관찰하는 Observer(=EventListener)가 있는 것인데, 다음과 같습니다.

```NotificationService.class```
```java
    @Transactional
    public void createAndPublishNotification(
            Long userId, NotificationType type, NotificationContent content) {
        Notification notification = Notification.create(userId, type, content);
        notificationAdaptor.save(notification);
        applicationEventPublisher.publishEvent(notification); // 이벤트 발행
    }
```

```EventListener.class```
```java
    // 이벤트 관찰
    @Async
    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
    public void notify(Notification notification) {
        notificationService.notify(notification.getUserId(), true); // 알림 전송
    }
```

위와 같은 방법을 사용하면 서비스 강결합을 줄일수 있는 등 다양한 이점이 있는데 가장 큰 이점은 다음과 같습니다.

## AS-IS

```NotificationService.class```
```java
    @Transactional
    public void createAndPublishNotification(
            Long userId, NotificationType type, NotificationContent content) {

        Notification notification = Notification.create(userId, type, content); // 알림 생성
        notificationAdaptor.save(notification); // 알림 저장
        notify(notification.getUserId(), true); // 알림 전송
        if(true) {
             throw new RuntimeException("혹시나 또 다른 로직을 수행하다가 에러가 발생했을 경우");
        }
    }
```
위 로직의 경우 에러가 발생했기에 알림 저장 부분은 Rollback이 일어나지만 외부 로직인 알림 전송 부분은 수행이 되게 되는 문제가 발생합니다.


## TO-BE
```NotificationService.class```
```java
    @Transactional
    public void createAndPublishNotification(
            Long userId, NotificationType type, NotificationContent content) {
        Notification notification = Notification.create(userId, type, content); // 알림 생성
        notificationAdaptor.save(notification); // 알림 저장
        applicationEventPublisher.publishEvent(notification); // 이벤트 발행
    }
```

```EventListener.class```
```java
    // 이벤트 관찰
    @Async
    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
    // 트랜잭션이 커밋 되었을 때만 수신
    public void notify(Notification notification) {
        notificationService.notify(notification.getUserId(), true); // 알림 전송
    }
```
하지만 위 방법의 경우 ```@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)```에 의해서 알림 ```createAndPublishNotification()``` 트랜잭션이 커밋되었을 경우에만 ```notificationService.notify(notification.getUserId(), true);```이 수행하게 되어 기존의 문제를 해결할 수 있습니다.


## 정리
저도 처음 사용해 보는 거라 정답이 아닐 수도 있고, 미숙할 수도 있씁니당.. 참고헀던 아티클들을 첨부합니당 다들 공부해 보세용

- https://tecoble.techcourse.co.kr/post/2020-09-30-event-publish/
- https://cheese10yun.github.io/event-transaction/#null
- https://wildeveloperetrain.tistory.com/246
- https://velog.io/@wlsgur1533/ApplicationEventPublisher%EB%A5%BC-%ED%99%9C%EC%9A%A9%ED%95%B4%EB%B3%B4%EC%9E%90


 