### PR TITLE
DEP-183: 주민증 수 대신 유저 수를 조회하도록 변경

### DIFF
--- a/Api/src/main/java/com/dingdong/api/community/dto/CommunityDetailsDto.java
+++ b/Api/src/main/java/com/dingdong/api/community/dto/CommunityDetailsDto.java
@@ -22,7 +22,7 @@ public class CommunityDetailsDto {
     private String title;
 
     @Schema(description = "주민 수")
-    private int userCount;
+    private long userCount;
 
     @Schema(description = "소개 글")
     private String description;
@@ -30,7 +30,7 @@ public class CommunityDetailsDto {
     @Schema(description = "행성 초대 코드")
     private String invitationCode;
 
-    public static CommunityDetailsDto of(Community community, int userCount) {
+    public static CommunityDetailsDto of(Community community, long userCount) {
         return CommunityDetailsDto.builder()
                 .communityId(community.getId())
                 .logoImageUrl(community.getLogoImageUrl())

--- a/Api/src/main/java/com/dingdong/api/community/dto/CommunityDetailsDto.java
+++ b/Api/src/main/java/com/dingdong/api/community/dto/CommunityDetailsDto.java
@@ -22,7 +22,7 @@ public class CommunityDetailsDto {
     private String title;
 
     @Schema(description = "주민 수")
-    private int idCardCount;
+    private int userCount;
 
     @Schema(description = "소개 글")
     private String description;
@@ -30,13 +30,13 @@ public class CommunityDetailsDto {
     @Schema(description = "행성 초대 코드")
     private String invitationCode;
 
-    public static CommunityDetailsDto of(Community community, int idCardCount) {
+    public static CommunityDetailsDto of(Community community, int userCount) {
         return CommunityDetailsDto.builder()
                 .communityId(community.getId())
                 .logoImageUrl(community.getLogoImageUrl())
                 .coverImageUrl(community.getCoverImageUrl())
                 .title(community.getName())
-                .idCardCount(idCardCount)
+                .userCount(userCount)
                 .description(community.getDescription())
                 .invitationCode(community.getInvitationCode())
                 .build();

--- a/Api/src/main/java/com/dingdong/api/community/service/CommunityService.java
+++ b/Api/src/main/java/com/dingdong/api/community/service/CommunityService.java
@@ -44,7 +44,7 @@ public class CommunityService {
 
     public CommunityDetailsDto getCommunityDetails(Long communityId) {
         Community community = communityAdaptor.findById(communityId);
-        int userCount = communityAdaptor.getUserCount(communityId);
+        long userCount = communityAdaptor.getUserCount(communityId);
 
         return CommunityDetailsDto.of(community, userCount);
     }

--- a/Api/src/main/java/com/dingdong/api/community/service/CommunityService.java
+++ b/Api/src/main/java/com/dingdong/api/community/service/CommunityService.java
@@ -44,8 +44,9 @@ public class CommunityService {
 
     public CommunityDetailsDto getCommunityDetails(Long communityId) {
         Community community = communityAdaptor.findById(communityId);
+        int userCount = communityAdaptor.getUserCount(communityId);
 
-        return CommunityDetailsDto.of(community, community.getIdCards().size());
+        return CommunityDetailsDto.of(community, userCount);
     }
 
     public List<CommunityListDto> getUserCommunityList(Long userId) {

--- a/Api/src/main/java/com/dingdong/api/idcard/dto/IdCardDetailsDto.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/dto/IdCardDetailsDto.java
@@ -14,6 +14,9 @@ public class IdCardDetailsDto {
     @Schema(description = "주민증 Id")
     private Long idCardId;
 
+    @Schema(description = "주민증 작성자 Id")
+    private Long userId;
+
     @Schema(description = "이름")
     private String nickname;
 
@@ -32,6 +35,7 @@ public class IdCardDetailsDto {
     public static IdCardDetailsDto of(IdCard idCard, List<KeywordDto> keywordDtos) {
         return IdCardDetailsDto.builder()
                 .idCardId(idCard.getId())
+                .userId(idCard.getUserInfo().getUserId())
                 .nickname(idCard.getNickname())
                 .profileImageUrl(idCard.getProfileImageUrl())
                 .aboutMe(idCard.getAboutMe())

--- a/Domain/src/main/java/com/dingdong/domain/domains/community/adaptor/CommunityAdaptor.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/community/adaptor/CommunityAdaptor.java
@@ -57,4 +57,8 @@ public class CommunityAdaptor {
     public boolean existsAdminByUserId(Long userId) {
         return adminRepository.existsByUserId(userId);
     }
+
+    public int getUserCount(Long communityId) {
+        return communityRepository.userCountByCommunityId(communityId);
+    }
 }

--- a/Domain/src/main/java/com/dingdong/domain/domains/community/adaptor/CommunityAdaptor.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/community/adaptor/CommunityAdaptor.java
@@ -58,7 +58,7 @@ public class CommunityAdaptor {
         return adminRepository.existsByUserId(userId);
     }
 
-    public int getUserCount(Long communityId) {
+    public long getUserCount(Long communityId) {
         return communityRepository.userCountByCommunityId(communityId);
     }
 }

--- a/Domain/src/main/java/com/dingdong/domain/domains/community/repository/CommunityRepository.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/community/repository/CommunityRepository.java
@@ -4,6 +4,7 @@ package com.dingdong.domain.domains.community.repository;
 import com.dingdong.domain.domains.community.domain.entity.Community;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -13,4 +14,7 @@ public interface CommunityRepository extends JpaRepository<Community, Long> {
     boolean existsCommunityByName(String name);
 
     Optional<Community> findByInvitationCode(String invitationCode);
+
+    @Query("SELECT COUNT(u) FROM User u JOIN u.communities c WHERE c.id = :communityId")
+    int userCountByCommunityId(Long communityId);
 }

--- a/Domain/src/main/java/com/dingdong/domain/domains/community/repository/CommunityRepository.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/community/repository/CommunityRepository.java
@@ -4,17 +4,14 @@ package com.dingdong.domain.domains.community.repository;
 import com.dingdong.domain.domains.community.domain.entity.Community;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CommunityRepository extends JpaRepository<Community, Long> {
+public interface CommunityRepository
+        extends JpaRepository<Community, Long>, CommunityRepositoryExtension {
     boolean existsCommunityByInvitationCode(String invitationCode);
 
     boolean existsCommunityByName(String name);
 
     Optional<Community> findByInvitationCode(String invitationCode);
-
-    @Query("SELECT COUNT(u) FROM User u JOIN u.communities c WHERE c.id = :communityId")
-    int userCountByCommunityId(Long communityId);
 }

--- a/Domain/src/main/java/com/dingdong/domain/domains/community/repository/CommunityRepositoryExtension.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/community/repository/CommunityRepositoryExtension.java
@@ -1,0 +1,5 @@
+package com.dingdong.domain.domains.community.repository;
+
+public interface CommunityRepositoryExtension {
+    long userCountByCommunityId(Long communityId);
+}

--- a/Domain/src/main/java/com/dingdong/domain/domains/community/repository/CommunityRepositoryImpl.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/community/repository/CommunityRepositoryImpl.java
@@ -1,7 +1,6 @@
 package com.dingdong.domain.domains.community.repository;
 
-import static com.dingdong.domain.domains.community.domain.entity.QCommunity.community;
-import static com.dingdong.domain.domains.user.domain.QUser.user;
+import static com.dingdong.domain.domains.community.domain.entity.QUserJoinCommunity.userJoinCommunity;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -14,10 +13,9 @@ public class CommunityRepositoryImpl implements CommunityRepositoryExtension {
     @Override
     public long userCountByCommunityId(Long communityId) {
         return queryFactory
-                .select(user.count())
-                .from(user)
-                .join(user.communities, community)
-                .where(community.id.eq(communityId))
+                .select(userJoinCommunity.count())
+                .from(userJoinCommunity)
+                .where(userJoinCommunity.communityId.eq(communityId))
                 .fetchOne();
     }
 }

--- a/Domain/src/main/java/com/dingdong/domain/domains/community/repository/CommunityRepositoryImpl.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/community/repository/CommunityRepositoryImpl.java
@@ -1,0 +1,23 @@
+package com.dingdong.domain.domains.community.repository;
+
+import static com.dingdong.domain.domains.community.domain.entity.QCommunity.community;
+import static com.dingdong.domain.domains.user.domain.QUser.user;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CommunityRepositoryImpl implements CommunityRepositoryExtension {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public long userCountByCommunityId(Long communityId) {
+        return queryFactory
+                .select(user.count())
+                .from(user)
+                .join(user.communities, community)
+                .where(community.id.eq(communityId))
+                .fetchOne();
+    }
+}


### PR DESCRIPTION
## 개요
- [DEP-183](https://darae0730.atlassian.net/jira/software/c/projects/DEP/issues/DEP-183?filter=allissues): 주민증 수 대신 유저 수를 조회하도록 변경

## 작업사항
- 행성 세부 조회에서 주민증 수 대신 행성에 가입된 유저 수를 조회해오도록 변경했습니다.

## 변경로직
- [User 엔티티](https://github.com/depromeet/Ding-dong-BE/blob/dev/Domain/src/main/java/com/dingdong/domain/domains/user/domain/User.java#L52)에 단방향으로 커뮤니티를 가지고 있어서 로직 고려해서 작성했습니다.

1. queryDSL로 한방쿼리 날리기
2. 현재처럼 JPQL 날리기

방법은 위 두 가지가 있는 것 같은데 일단은 2번으로 했습니다. 피드백 주시면 반영할게용 호홍