### PR TITLE
DEP-189: 행성 내 정보조회 시 주민증 없으면 에러가 발생함

### DIFF
--- a/Api/src/main/java/com/dingdong/api/community/dto/MyInfoInCommunityDto.java
+++ b/Api/src/main/java/com/dingdong/api/community/dto/MyInfoInCommunityDto.java
@@ -1,7 +1,9 @@
 package com.dingdong.api.community.dto;
 
 
+import com.dingdong.domain.domains.idcard.domain.entity.IdCard;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Optional;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -19,15 +21,18 @@ public class MyInfoInCommunityDto {
     private String profileImageUrl;
 
     @Schema(description = "관리자 인지 여부")
-    private boolean isAdmin;
+    private Boolean isAdmin;
 
-    public static MyInfoInCommunityDto of(
-            Long userId, String nickname, String profileImageUrl, boolean isAdmin) {
+    @Schema(description = "내 주민증 존재 여부")
+    private Boolean isExistsIdCard;
+
+    public static MyInfoInCommunityDto of(Long userId, Optional<IdCard> idCard, boolean isAdmin) {
         return MyInfoInCommunityDto.builder()
                 .userId(userId)
-                .nickname(nickname)
-                .profileImageUrl(profileImageUrl)
+                .nickname(idCard.map(IdCard::getNickname).orElse(null))
+                .profileImageUrl(idCard.map(IdCard::getProfileImageUrl).orElse(null))
                 .isAdmin(isAdmin)
+                .isExistsIdCard(idCard.isPresent())
                 .build();
     }
 }

--- a/Api/src/main/java/com/dingdong/api/community/service/CommunityService.java
+++ b/Api/src/main/java/com/dingdong/api/community/service/CommunityService.java
@@ -25,6 +25,7 @@ import com.dingdong.domain.domains.idcard.domain.entity.IdCard;
 import com.dingdong.domain.domains.user.domain.adaptor.UserAdaptor;
 import com.dingdong.domain.domains.user.domain.entity.User;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -157,16 +158,9 @@ public class CommunityService {
         communityValidator.validateUserExistInCommunity(user, communityId);
         Community community = communityAdaptor.findById(communityId);
 
-        IdCard idCard =
-                idCardAdaptor
-                        .findByUserAndCommunity(communityId, user.getId())
-                        .orElseThrow(() -> new BaseException(NOT_FOUND_ID_CARD));
+        Optional<IdCard> idCard = idCardAdaptor.findByUserAndCommunity(communityId, user.getId());
 
-        return MyInfoInCommunityDto.of(
-                user.getId(),
-                idCard.getNickname(),
-                idCard.getProfileImageUrl(),
-                community.isAdmin(user.getId()));
+        return MyInfoInCommunityDto.of(user.getId(), idCard, community.isAdmin(user.getId()));
     }
 
     private Community findAndValidateAdminUserInCommunity(Long communityId) {


### PR DESCRIPTION
## 개요
- [DEP-189](https://darae0730.atlassian.net/jira/software/c/projects/DEP/issues/DEP-189?filter=allissues): 행성 내 정보조회 시 주민증 없으면 에러가 발생함

## 문제 
- 주민증을 조회해올 때 값이 없으면 Error를 던지도록 되어있어서 주민증이 존재하지 않은 유저의 행성 정보를 얻을 수 없음

## 해결
- throw를 던지는 대신 Optional로 존재 여부 판단
- 행성 내 본인의 주민증이 존재하는지 여부를 나타내는 반환값 추가