### PR TITLE
DEP-189: 미확인 알림 없음에도 존재한다고 응답값 내려옴

### DIFF
--- a/Domain/src/main/java/com/dingdong/domain/domains/notification/adaptor/NotificationAdaptor.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/notification/adaptor/NotificationAdaptor.java
@@ -5,7 +5,6 @@ import static com.dingdong.domain.domains.notification.exception.NotificationErr
 import com.dingdong.core.annotation.Adaptor;
 import com.dingdong.core.exception.BaseException;
 import com.dingdong.domain.domains.notification.domain.entity.Notification;
-import com.dingdong.domain.domains.notification.domain.enums.NotificationStatus;
 import com.dingdong.domain.domains.notification.domain.vo.NotificationVO;
 import com.dingdong.domain.domains.notification.repository.NotificationRepository;
 import java.util.List;
@@ -29,8 +28,7 @@ public class NotificationAdaptor {
     }
 
     public boolean existsUnreadNotifications(Long userId) {
-        return notificationRepository.existsByUserIdAndNotificationStatus(
-                userId, NotificationStatus.UNREAD);
+        return notificationRepository.existsUnreadNotification(userId);
     }
 
     public List<Notification> findByUserId(Long userId) {

--- a/Domain/src/main/java/com/dingdong/domain/domains/notification/repository/NotificationRepository.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/notification/repository/NotificationRepository.java
@@ -2,13 +2,10 @@ package com.dingdong.domain.domains.notification.repository;
 
 
 import com.dingdong.domain.domains.notification.domain.entity.Notification;
-import com.dingdong.domain.domains.notification.domain.enums.NotificationStatus;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository
         extends JpaRepository<Notification, Long>, NotificationRepositoryExtension {
-    boolean existsByUserIdAndNotificationStatus(Long userId, NotificationStatus notificationStatus);
-
     List<Notification> findAllByUserId(Long userId);
 }

--- a/Domain/src/main/java/com/dingdong/domain/domains/notification/repository/NotificationRepositoryExtension.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/notification/repository/NotificationRepositoryExtension.java
@@ -7,4 +7,6 @@ import org.springframework.data.domain.Slice;
 
 public interface NotificationRepositoryExtension {
     Slice<NotificationVO> findNotificationByConditionInPage(Long userId, Pageable pageable);
+
+    boolean existsUnreadNotification(Long userId);
 }

--- a/Domain/src/main/java/com/dingdong/domain/domains/notification/repository/NotificationRepositoryImpl.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/notification/repository/NotificationRepositoryImpl.java
@@ -6,8 +6,11 @@ import static com.dingdong.domain.domains.idcard.domain.entity.QIdCard.idCard;
 import static com.dingdong.domain.domains.notification.domain.entity.QNotification.notification;
 
 import com.dingdong.domain.common.util.SliceUtil;
+import com.dingdong.domain.domains.notification.domain.entity.Notification;
+import com.dingdong.domain.domains.notification.domain.enums.NotificationStatus;
 import com.dingdong.domain.domains.notification.domain.vo.NotificationVO;
 import com.dingdong.domain.domains.notification.domain.vo.QNotificationVO;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
@@ -19,13 +22,27 @@ import org.springframework.data.domain.Slice;
 @RequiredArgsConstructor
 public class NotificationRepositoryImpl implements NotificationRepositoryExtension {
     private final JPAQueryFactory queryFactory;
+    private static final Timestamp FIVE_WEEKS_AGO =
+            Timestamp.valueOf(LocalDateTime.now().minusWeeks(5));
+
+    private JPAQuery<Notification> buildQuery(Long userId) {
+        return queryFactory
+                .selectFrom(notification)
+                .join(community)
+                .on(community.id.eq(notification.content.communityId))
+                .join(idCard)
+                .on(idCard.userInfo.userId.eq(notification.content.fromUserId))
+                .join(comment)
+                .on(notification.content.commentId.eq(comment.id))
+                .where(
+                        notification.userId.eq(userId),
+                        notification.createdAt.after(NotificationRepositoryImpl.FIVE_WEEKS_AGO));
+    }
 
     @Override
     public Slice<NotificationVO> findNotificationByConditionInPage(Long userId, Pageable pageable) {
-        Timestamp fiveWeeksAgo = Timestamp.valueOf(LocalDateTime.now().minusWeeks(5));
-
         List<NotificationVO> notificationVOs =
-                queryFactory
+                buildQuery(userId)
                         .select(
                                 new QNotificationVO(
                                         notification.id,
@@ -40,21 +57,21 @@ public class NotificationRepositoryImpl implements NotificationRepositoryExtensi
                                         community.id,
                                         comment.content,
                                         idCard.id))
-                        .from(notification)
-                        .where(
-                                notification.userId.eq(userId),
-                                notification.createdAt.after(fiveWeeksAgo))
-                        .join(community)
-                        .on(community.id.eq(notification.content.communityId))
-                        .join(idCard)
-                        .on(idCard.userInfo.userId.eq(notification.content.fromUserId))
-                        .join(comment)
-                        .on(notification.content.commentId.eq(comment.id))
                         .orderBy(notification.id.desc())
                         .offset(pageable.getOffset())
                         .limit(pageable.getPageSize() + 1)
                         .fetch();
 
         return SliceUtil.valueOf(notificationVOs, pageable);
+    }
+
+    @Override
+    public boolean existsUnreadNotification(Long userId) {
+        long count =
+                buildQuery(userId)
+                        .where(notification.notificationStatus.eq(NotificationStatus.UNREAD))
+                        .fetchCount();
+
+        return count > 0;
     }
 }


### PR DESCRIPTION
## 개요
- [DEP-189](https://darae0730.atlassian.net/jira/software/c/projects/DEP/issues/DEP-189?filter=allissues): 미확인 알림 없음에도 존재한다고 응답값 내려옴

## 작업사항
- 기존에 미확인 알림 존재 여부를 ```NotificationStatus```가 ```Unread```인게 있는지 없는지 여부로 판단했는데, 실제 ```Notification```의 알림 목록을 조회할때는 다음과 같은 조건을 가지기 때문에, ```Unread```임에도 불구하고 다음과 같은 join 조건을 만족하지 못하면 알림 목록에 노출되지 않아 버그로 인식되는 문제가 있음
![image](https://github.com/depromeet/Ding-dong-BE/assets/74492426/aab16a9d-e483-4601-823c-a2d743c20790)

## 변경로직
- 알림 조회와 미확인 알림 존재 여부의 쿼리를 일치시켰음