### PR TITLE
Dep-191: 대댓글 조회 분리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ out/
 *.xlsx
 
 Domain/src/main/generated/**/*.java
+
+.DS_Store

--- a/Api/src/main/java/com/dingdong/api/idcard/controller/IdCardController.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/controller/IdCardController.java
@@ -7,6 +7,7 @@ import com.dingdong.api.idcard.controller.request.CreateCommentRequest;
 import com.dingdong.api.idcard.controller.request.CreateIdCardRequest;
 import com.dingdong.api.idcard.controller.request.UpdateIdCardRequest;
 import com.dingdong.api.idcard.controller.response.CommentCountResponse;
+import com.dingdong.api.idcard.controller.response.CommentRepliesResponse;
 import com.dingdong.api.idcard.controller.response.IdCardDetailsResponse;
 import com.dingdong.api.idcard.dto.CommentDto;
 import com.dingdong.api.idcard.service.CommentService;
@@ -84,6 +85,14 @@ public class IdCardController {
     public SliceResponse<CommentDto> getComments(
             @PathVariable Long idCardsId, @PageableDefault Pageable pageable) {
         return SliceResponse.from(commentService.getComments(idCardsId, pageable));
+    }
+
+    @Operation(summary = "주민증 대댓글 조회")
+    @GetMapping("/{idCardsId}/comments/{commentId}/replies")
+    public CommentRepliesResponse getReplies(
+            @PathVariable Long idCardsId, @PathVariable Long commentId) {
+        return CommentRepliesResponse.of(
+                commentId, commentService.getReplies(idCardsId, commentId));
     }
 
     @Operation(summary = "주민증 댓글 좋아요")

--- a/Api/src/main/java/com/dingdong/api/idcard/controller/response/CommentRepliesResponse.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/controller/response/CommentRepliesResponse.java
@@ -1,0 +1,26 @@
+package com.dingdong.api.idcard.controller.response;
+
+
+import com.dingdong.api.idcard.dto.CommentReplyDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CommentRepliesResponse {
+
+    @Schema(description = "대댓글이 달린 댓글의 id")
+    private final Long commentId;
+
+    @Schema(description = "대댓글 정보")
+    private final List<CommentReplyDto> repliesInfo;
+
+    public static CommentRepliesResponse of(Long commentId, List<CommentReplyDto> repliesInfo) {
+        return CommentRepliesResponse.builder()
+                .commentId(commentId)
+                .repliesInfo(repliesInfo)
+                .build();
+    }
+}

--- a/Api/src/main/java/com/dingdong/api/idcard/dto/CommentDto.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/dto/CommentDto.java
@@ -31,7 +31,7 @@ public class CommentDto {
     private final LikeDto commentLikeInfo;
 
     @Schema(description = "대댓글 갯수 (답글 N개 더보기)")
-    private final Long repliesCount;
+    private final int repliesCount;
 
     public static CommentDto of(Comment comment, UserInfo userInfo, Long currentUserId) {
         return CommentDto.builder()
@@ -40,7 +40,7 @@ public class CommentDto {
                 .content(comment.getContent())
                 .writerInfo(UserInfoDto.from(userInfo))
                 .commentLikeInfo(LikeDto.ofCommentLike(comment.getLikes(), currentUserId))
-                .repliesCount((long) comment.getReplies().size())
+                .repliesCount(comment.getReplies().size())
                 .createdAt(comment.getCreatedAt())
                 .build();
     }

--- a/Api/src/main/java/com/dingdong/api/idcard/dto/CommentDto.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/dto/CommentDto.java
@@ -41,12 +41,6 @@ public class CommentDto {
                 .content(comment.getContent())
                 .writerInfo(UserInfoDto.from(userInfo))
                 .commentLikeInfo(LikeDto.ofCommentLike(comment.getLikes(), currentUserId))
-                .commentReplyInfos(
-                        comment.getReplies().stream()
-                                .map(
-                                        commentReply ->
-                                                CommentReplyDto.of(commentReply, currentUserId))
-                                .toList())
                 .createdAt(comment.getCreatedAt())
                 .build();
     }

--- a/Api/src/main/java/com/dingdong/api/idcard/dto/CommentDto.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/dto/CommentDto.java
@@ -30,6 +30,9 @@ public class CommentDto {
     @Schema(description = "댓글 좋아요 정보 dto")
     private final LikeDto commentLikeInfo;
 
+    @Schema(description = "대댓글 갯수 (답글 N개 더보기)")
+    private final Long repliesCount;
+
     public static CommentDto of(Comment comment, UserInfo userInfo, Long currentUserId) {
         return CommentDto.builder()
                 .idCardId(comment.getIdCardId())
@@ -37,6 +40,7 @@ public class CommentDto {
                 .content(comment.getContent())
                 .writerInfo(UserInfoDto.from(userInfo))
                 .commentLikeInfo(LikeDto.ofCommentLike(comment.getLikes(), currentUserId))
+                .repliesCount((long) comment.getReplies().size())
                 .createdAt(comment.getCreatedAt())
                 .build();
     }

--- a/Api/src/main/java/com/dingdong/api/idcard/dto/CommentDto.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/dto/CommentDto.java
@@ -5,7 +5,6 @@ import com.dingdong.domain.domains.idcard.domain.entity.Comment;
 import com.dingdong.domain.domains.idcard.domain.model.UserInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.sql.Timestamp;
-import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -30,9 +29,6 @@ public class CommentDto {
 
     @Schema(description = "댓글 좋아요 정보 dto")
     private final LikeDto commentLikeInfo;
-
-    @Schema(description = "댓글 대댓글 정보 dto list")
-    private final List<CommentReplyDto> commentReplyInfos;
 
     public static CommentDto of(Comment comment, UserInfo userInfo, Long currentUserId) {
         return CommentDto.builder()

--- a/Api/src/main/java/com/dingdong/api/idcard/dto/CommentReplyDto.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/dto/CommentReplyDto.java
@@ -2,6 +2,7 @@ package com.dingdong.api.idcard.dto;
 
 
 import com.dingdong.domain.domains.idcard.domain.entity.CommentReply;
+import com.dingdong.domain.domains.idcard.domain.model.UserInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.sql.Timestamp;
 import lombok.Builder;
@@ -20,14 +21,19 @@ public class CommentReplyDto {
     @Schema(description = "대댓글 생성일")
     private final Timestamp createdAt;
 
+    @Schema(description = "댓글 작성자 정보")
+    private final UserInfoDto writerInfo;
+
     @Schema(description = "대댓글 좋아요 정보 dto")
     private final LikeDto commentReplyLikeInfo;
 
-    public static CommentReplyDto of(CommentReply commentReply, Long currentUserId) {
+    public static CommentReplyDto of(
+            CommentReply commentReply, UserInfo userInfo, Long currentUserId) {
         return CommentReplyDto.builder()
                 .commentReplyId(commentReply.getId())
                 .content(commentReply.getContent())
                 .createdAt(commentReply.getCreatedAt())
+                .writerInfo(UserInfoDto.from(userInfo))
                 .commentReplyLikeInfo(
                         LikeDto.ofCommentReplyLike(commentReply.getReplyLikes(), currentUserId))
                 .build();

--- a/Api/src/main/java/com/dingdong/api/idcard/service/CommentService.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/service/CommentService.java
@@ -113,6 +113,7 @@ public class CommentService {
                 pageable);
     }
 
+    /** 대댓글 조회 */
     public List<CommentReplyDto> getReplies(Long idCardId, Long commentId) {
         User currentUser = userHelper.getCurrentUser();
         IdCard idCard = idCardAdaptor.findById(idCardId);

--- a/Domain/src/main/java/com/dingdong/domain/domains/idcard/adaptor/CommentAdaptor.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/idcard/adaptor/CommentAdaptor.java
@@ -12,6 +12,7 @@ import com.dingdong.domain.domains.idcard.domain.entity.Comment;
 import com.dingdong.domain.domains.idcard.domain.entity.CommentLike;
 import com.dingdong.domain.domains.idcard.domain.entity.CommentReply;
 import com.dingdong.domain.domains.idcard.domain.entity.CommentReplyLike;
+import com.dingdong.domain.domains.idcard.domain.model.CommentReplyVo;
 import com.dingdong.domain.domains.idcard.domain.model.CommentVo;
 import com.dingdong.domain.domains.idcard.repository.CommentRepository;
 import java.util.List;
@@ -72,5 +73,9 @@ public class CommentAdaptor {
 
     public List<Comment> findAllByIdCard(Long idCardId) {
         return commentRepository.findAllByIdCardIdAndIsDeleted(idCardId, N);
+    }
+
+    public List<CommentReplyVo> findCommentReplyByCommentId(Long commentId, Long communityId) {
+        return commentRepository.findReplies(commentId, communityId);
     }
 }

--- a/Domain/src/main/java/com/dingdong/domain/domains/idcard/domain/model/CommentReplyVo.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/idcard/domain/model/CommentReplyVo.java
@@ -1,0 +1,18 @@
+package com.dingdong.domain.domains.idcard.domain.model;
+
+
+import com.dingdong.domain.domains.idcard.domain.entity.CommentReply;
+import lombok.Getter;
+
+@Getter
+public class CommentReplyVo {
+
+    private final CommentReply commentReply;
+
+    private final UserInfo userInfo;
+
+    public CommentReplyVo(CommentReply commentReply, UserInfo userInfo) {
+        this.commentReply = commentReply;
+        this.userInfo = userInfo;
+    }
+}

--- a/Domain/src/main/java/com/dingdong/domain/domains/idcard/repository/CommentRepositoryExtension.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/idcard/repository/CommentRepositoryExtension.java
@@ -1,11 +1,15 @@
 package com.dingdong.domain.domains.idcard.repository;
 
 
+import com.dingdong.domain.domains.idcard.domain.model.CommentReplyVo;
 import com.dingdong.domain.domains.idcard.domain.model.CommentVo;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface CommentRepositoryExtension {
 
     Slice<CommentVo> findCommentsByIdCardId(Long idCardId, Long communityId, Pageable pageable);
+
+    List<CommentReplyVo> findReplies(Long commentId, Long communityId);
 }

--- a/Domain/src/main/java/com/dingdong/domain/domains/idcard/repository/CommentRepositoryImpl.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/idcard/repository/CommentRepositoryImpl.java
@@ -3,9 +3,11 @@ package com.dingdong.domain.domains.idcard.repository;
 import static com.dingdong.domain.common.consts.Status.N;
 import static com.dingdong.domain.domains.idcard.domain.entity.QComment.comment;
 import static com.dingdong.domain.domains.idcard.domain.entity.QCommentLike.commentLike;
+import static com.dingdong.domain.domains.idcard.domain.entity.QCommentReply.commentReply;
 import static com.dingdong.domain.domains.idcard.domain.entity.QIdCard.idCard;
 
 import com.dingdong.domain.common.util.SliceUtil;
+import com.dingdong.domain.domains.idcard.domain.model.CommentReplyVo;
 import com.dingdong.domain.domains.idcard.domain.model.CommentVo;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -39,5 +41,21 @@ public class CommentRepositoryImpl implements CommentRepositoryExtension {
                         .fetch();
 
         return SliceUtil.valueOf(comments, pageable);
+    }
+
+    @Override
+    public List<CommentReplyVo> findReplies(Long commentId, Long communityId) {
+        return queryFactory
+                .select(
+                        Projections.constructor(
+                                CommentReplyVo.class, commentReply, idCard.userInfo))
+                .from(commentReply)
+                .join(idCard)
+                .on(
+                        idCard.userInfo.userId.eq(commentReply.userId),
+                        idCard.communityId.eq(communityId))
+                .where(commentReply.commentId.eq(commentId))
+                .orderBy(commentReply.id.desc())
+                .fetch();
     }
 }

--- a/Domain/src/main/java/com/dingdong/domain/domains/idcard/repository/CommentRepositoryImpl.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/idcard/repository/CommentRepositoryImpl.java
@@ -55,7 +55,7 @@ public class CommentRepositoryImpl implements CommentRepositoryExtension {
                         idCard.userInfo.userId.eq(commentReply.userId),
                         idCard.communityId.eq(communityId))
                 .where(commentReply.commentId.eq(commentId))
-                .orderBy(commentReply.id.desc())
+                .orderBy(commentReply.id.asc())
                 .fetch();
     }
 }

--- a/Domain/src/main/java/com/dingdong/domain/domains/idcard/validator/IdCardValidator.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/idcard/validator/IdCardValidator.java
@@ -1,6 +1,7 @@
 package com.dingdong.domain.domains.idcard.validator;
 
 import static com.dingdong.domain.domains.idcard.exception.IdCardErrorCode.ALREADY_EXIST_ID_CARD;
+import static com.dingdong.domain.domains.idcard.exception.IdCardErrorCode.NOT_EXIST_ID_CARD_IN_COMMUNITY;
 import static com.dingdong.domain.domains.idcard.exception.IdCardErrorCode.NOT_VALID_ID_CARD_COMMENT;
 
 import com.dingdong.core.annotation.Validator;
@@ -30,5 +31,11 @@ public class IdCardValidator {
         if (!Objects.equals(comment.getIdCardId(), idCard.getId())) {
             throw new BaseException(NOT_VALID_ID_CARD_COMMENT);
         }
+    }
+
+    public void validateUserIdCardInCommunity(Long communityId, Long userId) {
+        idCardAdaptor
+                .findByUserAndCommunity(communityId, userId)
+                .orElseThrow(() -> new BaseException(NOT_EXIST_ID_CARD_IN_COMMUNITY));
     }
 }


### PR DESCRIPTION
## 개요
- [DEP-191 대댓글 조회 분리 API 작성](https://darae0730.atlassian.net/jira/software/c/projects/DEP/boards/2/timeline?selectedIssue=DEP-191)을 했씁니다

## 작업사항
- 댓글 조회 시 대댓글도 한번에 불러오는게 쿼리를 많이 쓰는 것 같아 분리했습니당
- 처음에 아무생각없이 짜니까 N+1 문제 나서 dsl로 조인해서 한번에 가져오는 로직으로 수정했어요

![스크린샷 2023-07-09 13 48 58](https://github.com/depromeet/Ding-dong-BE/assets/59060780/e72f3795-b3a1-45ad-a307-ca7748f34107)

- dto 분리하면서 위 사진처럼 N개 더보기가 있길래 그냥 댓글 조회 시 dto에 넣어버렸습니당
-  트랜잭션 걸려있는 서비스 레이어에서 하는거라 레이지 익셉션은 안날거에용
- 근데 옛날 기억에 댓글과 대댓글 정렬 조건이 달랐던거 같은데 뭔가 아닌것 같아서 일단 desc로 통일했어용 (일단 윤호님께 여쭤볼게요)
- 정상 작동 확인했습니다

## 변경로직

![스크린샷 2023-07-09 13 51 29](https://github.com/depromeet/Ding-dong-BE/assets/59060780/4ba923c6-f073-4d80-94e0-e215be4b922e)

- 주형님 위에 커밋에서 제가 걸어놓았던 댓글, 대댓글 생성 시 검증 조건이 사라졌더라구요 근데 또 보니까 문제가 있는 코드긴 했음.. 그래서 새로 만들었어용 
``` java
    public void validateUserIdCardInCommunity(Long communityId, Long userId) {
        idCardAdaptor
                .findByUserAndCommunity(communityId, userId)
                .orElseThrow(() -> new BaseException(NOT_EXIST_ID_CARD_IN_COMMUNITY));
    }
```
- 용도는 주민증 없는 유저 쳐내는 것 입니당 (댓글, 대댓글 생성 및 좋아요 누를 때)