### PR TITLE
DEP-194: 행성 내 모든 주민증 조회 및 내 정보 조회 시 주민증 댓글 개수 카운팅 추가

### DIFF
--- a/Api/src/main/java/com/dingdong/api/community/dto/CommunityIdCardsDto.java
+++ b/Api/src/main/java/com/dingdong/api/community/dto/CommunityIdCardsDto.java
@@ -28,13 +28,17 @@ public class CommunityIdCardsDto {
     @Schema(description = "키워드 타이틀 목록")
     private final List<String> keywordTitles;
 
-    public static CommunityIdCardsDto of(IdCard idCard, List<Keyword> keywords) {
+    @Schema(description = "댓글 개수")
+    private final Long commentCount;
+
+    public static CommunityIdCardsDto of(IdCard idCard, List<Keyword> keywords, Long commentCount) {
         return CommunityIdCardsDto.builder()
                 .idCardId(idCard.getId())
                 .nickname(idCard.getNickname())
                 .aboutMe(idCard.getAboutMe())
                 .characterType(idCard.getCharacterType())
                 .keywordTitles(keywords.stream().map(Keyword::getTitle).toList())
+                .commentCount(commentCount)
                 .build();
     }
 }

--- a/Api/src/main/java/com/dingdong/api/community/dto/MyInfoInCommunityDto.java
+++ b/Api/src/main/java/com/dingdong/api/community/dto/MyInfoInCommunityDto.java
@@ -26,13 +26,18 @@ public class MyInfoInCommunityDto {
     @Schema(description = "내 주민증 존재 여부")
     private Boolean isExistsIdCard;
 
-    public static MyInfoInCommunityDto of(Long userId, Optional<IdCard> idCard, boolean isAdmin) {
+    @Schema(description = "주민증의 댓글 개수")
+    private Long commentCount;
+
+    public static MyInfoInCommunityDto of(
+            Long userId, Optional<IdCard> idCard, boolean isAdmin, Long commentCount) {
         return MyInfoInCommunityDto.builder()
                 .userId(userId)
                 .nickname(idCard.map(IdCard::getNickname).orElse(null))
                 .profileImageUrl(idCard.map(IdCard::getProfileImageUrl).orElse(null))
                 .isAdmin(isAdmin)
                 .isExistsIdCard(idCard.isPresent())
+                .commentCount(commentCount)
                 .build();
     }
 }

--- a/Api/src/main/java/com/dingdong/api/community/service/CommunityService.java
+++ b/Api/src/main/java/com/dingdong/api/community/service/CommunityService.java
@@ -46,7 +46,11 @@ public class CommunityService {
     private final CommentAdaptor commentAdaptor;
 
     public CommunityDetailsDto getCommunityDetails(Long communityId) {
+        User currentUser = userHelper.getCurrentUser();
         Community community = communityAdaptor.findById(communityId);
+
+        communityValidator.validateUserExistInCommunity(currentUser, communityId);
+
         long userCount = communityAdaptor.getUserCount(communityId);
 
         return CommunityDetailsDto.of(community, userCount);
@@ -91,6 +95,10 @@ public class CommunityService {
 
     /** 행성의 모든 주민증 조회 */
     public Slice<CommunityIdCardsDto> getCommunityIdCards(Long communityId, Pageable pageable) {
+
+        User currentUser = userHelper.getCurrentUser();
+        communityValidator.validateUserExistInCommunity(currentUser, communityId);
+
         Slice<IdCard> idCards = idCardAdaptor.findIdCardByConditionInPage(communityId, pageable);
 
         return SliceUtil.valueOf(

--- a/Api/src/main/java/com/dingdong/api/community/service/CommunityService.java
+++ b/Api/src/main/java/com/dingdong/api/community/service/CommunityService.java
@@ -108,7 +108,7 @@ public class CommunityService {
                                         CommunityIdCardsDto.of(
                                                 idCard,
                                                 idCard.getKeywords(),
-                                                commentAdaptor.findCountCommentByIdCard(
+                                                commentAdaptor.findCommentCountByIdCard(
                                                         idCard.getId())))
                         .toList(),
                 pageable);
@@ -180,7 +180,7 @@ public class CommunityService {
                 community.isAdmin(user.getId()),
                 idCard.map(
                                 presentIdCard ->
-                                        commentAdaptor.findCountCommentByIdCard(
+                                        commentAdaptor.findCommentCountByIdCard(
                                                 presentIdCard.getId()))
                         .orElse(null));
     }

--- a/Api/src/main/java/com/dingdong/api/config/security/CorsConfig.java
+++ b/Api/src/main/java/com/dingdong/api/config/security/CorsConfig.java
@@ -21,7 +21,6 @@ public class CorsConfig implements WebMvcConfigurer {
         String[] patterns = allowedOriginPatterns.toArray(String[]::new);
         registry.addMapping("/**")
                 .allowedMethods("*")
-                .allowedOriginPatterns(patterns)
                 .exposedHeaders("Set-Cookie")
                 .allowCredentials(true);
     }

--- a/Api/src/main/java/com/dingdong/api/idcard/service/CommentService.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/service/CommentService.java
@@ -7,6 +7,7 @@ import com.dingdong.api.idcard.dto.CommentDto;
 import com.dingdong.api.idcard.dto.CommentReplyDto;
 import com.dingdong.api.notification.service.NotificationService;
 import com.dingdong.domain.common.util.SliceUtil;
+import com.dingdong.domain.domains.community.validator.CommunityValidator;
 import com.dingdong.domain.domains.idcard.adaptor.CommentAdaptor;
 import com.dingdong.domain.domains.idcard.adaptor.IdCardAdaptor;
 import com.dingdong.domain.domains.idcard.domain.entity.Comment;
@@ -44,6 +45,8 @@ public class CommentService {
     private final CommentValidator commentValidator;
 
     private final NotificationService notificationService;
+
+    private final CommunityValidator communityValidator;
 
     /** 댓글 생성 */
     @Transactional
@@ -97,6 +100,7 @@ public class CommentService {
     public Slice<CommentDto> getComments(Long idCardId, Pageable pageable) {
         User currentUser = userHelper.getCurrentUser();
         IdCard idCard = idCardAdaptor.findById(idCardId);
+        communityValidator.validateUserExistInCommunity(currentUser, idCard.getCommunityId());
         Slice<CommentVo> comments =
                 commentAdaptor.findCommentsByIdCard(
                         idCard.getId(), idCard.getCommunityId(), pageable);
@@ -119,6 +123,8 @@ public class CommentService {
         IdCard idCard = idCardAdaptor.findById(idCardId);
 
         Long communityId = idCard.getCommunityId();
+
+        communityValidator.validateUserExistInCommunity(currentUser, idCard.getCommunityId());
 
         Comment comment = commentAdaptor.findById(commentId);
 

--- a/Api/src/main/java/com/dingdong/api/idcard/service/IdCardService.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/service/IdCardService.java
@@ -80,7 +80,6 @@ public class IdCardService {
 
         validateIsJoinUser(userHelper.getCurrentUser(), community.getId());
 
-        // Todo: 캐릭터 당 디폴트 이미지 넣는 로직 필요
         String userProfileImage =
                 request.getProfileImageUrl() == null
                         ? ID_CARD_DEFAULT_IMAGE

--- a/Domain/src/main/java/com/dingdong/domain/domains/community/exception/CommunityErrorCode.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/community/exception/CommunityErrorCode.java
@@ -26,7 +26,7 @@ public enum CommunityErrorCode implements BaseErrorCode {
     @ExplainError("이미 가입된 행성에 가입 시도를 할 때 발생하는 오류입니다.")
     ALREADY_JOIN_COMMUNITY(REDIRECTION, "Community-300-1", "이미 가입된 행성입니다."),
     @ExplainError("가입하지 않은 행성에서 행성 떠나기를 시도할 때 발생하는 오류입니다.")
-    NOT_JOIN_COMMUNITY(BAD_REQUEST, "Community-400-4", "가입하지 않은 행성입니다.");
+    NOT_JOIN_COMMUNITY(FORBIDDEN, "Community-403-2", "행성 정보 조회 및 수정 권한이 없습니다.");
 
     private final Integer statusCode;
     private final String errorCode;

--- a/Domain/src/main/java/com/dingdong/domain/domains/idcard/adaptor/CommentAdaptor.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/idcard/adaptor/CommentAdaptor.java
@@ -79,7 +79,7 @@ public class CommentAdaptor {
         return commentRepository.findReplies(commentId, communityId);
     }
 
-    public Long findCountCommentByIdCard(Long idCardId) {
+    public Long findCommentCountByIdCard(Long idCardId) {
         return commentRepository.countByIdCardIdAndIsDeleted(idCardId, N);
     }
 }

--- a/Domain/src/main/java/com/dingdong/domain/domains/idcard/adaptor/CommentAdaptor.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/idcard/adaptor/CommentAdaptor.java
@@ -78,4 +78,8 @@ public class CommentAdaptor {
     public List<CommentReplyVo> findCommentReplyByCommentId(Long commentId, Long communityId) {
         return commentRepository.findReplies(commentId, communityId);
     }
+
+    public Long findCountCommentByIdCard(Long idCardId) {
+        return commentRepository.countByIdCardIdAndIsDeleted(idCardId, N);
+    }
 }

--- a/Domain/src/main/java/com/dingdong/domain/domains/idcard/exception/IdCardErrorCode.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/idcard/exception/IdCardErrorCode.java
@@ -1,6 +1,7 @@
 package com.dingdong.domain.domains.idcard.exception;
 
 import static com.dingdong.core.consts.StaticVal.BAD_REQUEST;
+import static com.dingdong.core.consts.StaticVal.FORBIDDEN;
 import static com.dingdong.core.consts.StaticVal.NOT_FOUND;
 
 import com.dingdong.core.annotation.ExplainError;
@@ -33,7 +34,7 @@ public enum IdCardErrorCode implements BaseErrorCode {
     NOT_VALID_COMMENT_REPLY(BAD_REQUEST, "Comment-400-2", "해당 댓글의 대댓글이 아닙니다."),
     NOT_FOUND_COMMENT_REPLY_LIKE(NOT_FOUND, "CommentReplyLike-404-1", "존재하지 않는 대댓글 좋아요입니다."),
     NOT_EXIST_ID_CARD_IN_COMMUNITY(
-            BAD_REQUEST, "IdCard-400-3", "행성에 주민증을 만들지 않은 유저는 댓글, 좋아요를 등록 할 수 없습니다."),
+            FORBIDDEN, "IdCard-403-1", "행성에 주민증을 만들지 않은 유저는 댓글, 좋아요를 등록 할 수 있는 권한이 없습니다."),
     NOT_VALID_ID_CARD_USER(BAD_REQUEST, "IdCard-400-4", "해당 유저가 작성한 주민증이 아닙니다.");
 
     private final Integer statusCode;

--- a/Domain/src/main/java/com/dingdong/domain/domains/idcard/repository/CommentRepository.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/idcard/repository/CommentRepository.java
@@ -13,4 +13,6 @@ public interface CommentRepository
     Optional<Comment> findByIdAndIsDeleted(Long commentId, Status isDeleted);
 
     List<Comment> findAllByIdCardIdAndIsDeleted(Long idCardId, Status isDeleted);
+
+    Long countByIdCardIdAndIsDeleted(Long idCardId, Status isDeleted);
 }


### PR DESCRIPTION
## 개요
- [DEP-194](https://darae0730.atlassian.net/jira/software/c/projects/DEP/boards/2/timeline?selectedIssue=DEP-194)를 했어용

## 작업사항
- [DEP-193](https://darae0730.atlassian.net/jira/software/c/projects/DEP/boards/2/timeline?selectedIssue=DEP-193)으로 QA 대응 만들어놨어요
- 윤호님이 주민증 리스트 조회 할 때도 댓글 카운팅 필요하다해서 컬럼 추가했습니당
- 어떻게든... querydsl 써서 한방쿼리로 하려했는데 잘 안되네요... 결국 N+1 되는 코드를 작성해버리고 말았습니다
- [DDD 시 설계를 잘해야 하는 이유](https://private-space.tistory.com/94) 이거 보면서 연관관계를 무조건 제거하는 것이 아닌 같은 목적을 가지고 있는 단위에선 열심히 걸어야하는것을 봤는데 오늘 다시금 깨달았네요 댓글-주민증 연관관계가 필요합니다 ㅜㅜ
- 혹시 최적화 방법 생각나시면 언제든 코멘트 달아주시면 수정하러 달려오겠습니당
- ![스크린샷 2023-07-12 13 06 58](https://github.com/depromeet/Ding-dong-BE/assets/59060780/d498f817-6a3c-4476-9b91-be8b69f62efc)
- 추가로 위 사진처럼 joinCommunities에 커뮤니티 id가 널이 들어갈 수 있나용?? 이거 뭔가 좀 이상한디


## 변경로직
- 추가로 윤호님이 요청하셔서 cors origin pattern 전부 해제했습니당
### AS-IS
```java
@Override
    public void addCorsMappings(CorsRegistry registry) {
        ArrayList<String> allowedOriginPatterns = new ArrayList<>();
        allowedOriginPatterns.add("http://localhost:3000");
        /*
        Todo: 도메인 나오면 추가예정
         */
        String[] patterns = allowedOriginPatterns.toArray(String[]::new);
        registry.addMapping("/**")
                .allowedMethods("*")
                .exposedHeaders("Set-Cookie")
                .allowedOriginPatterns(patterns)
                .allowCredentials(true);
    }
```

### TO-BE
``` java
@Override
    public void addCorsMappings(CorsRegistry registry) {
        ArrayList<String> allowedOriginPatterns = new ArrayList<>();
        allowedOriginPatterns.add("http://localhost:3000");
        /*
        Todo: 도메인 나오면 추가예정
         */
        String[] patterns = allowedOriginPatterns.toArray(String[]::new);
        registry.addMapping("/**")
                .allowedMethods("*")
                .exposedHeaders("Set-Cookie")
                .allowedOriginPatterns("*")
                .allowCredentials(true);
    }
```