### PR TITLE
DEP-196: 알람과 행성내 주민 이름 불일치 에러 해결

### DIFF
--- a/Api/src/main/java/com/dingdong/api/global/event/EventListener.java
+++ b/Api/src/main/java/com/dingdong/api/global/event/EventListener.java
@@ -15,6 +15,6 @@ public class EventListener {
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
     public void notify(Notification notification) {
-        notificationService.notify(notification.getUserId(), true);
+        notificationService.notify(notification.getToUserId(), true);
     }
 }

--- a/Api/src/main/java/com/dingdong/api/notification/dto/NotificationDto.java
+++ b/Api/src/main/java/com/dingdong/api/notification/dto/NotificationDto.java
@@ -46,7 +46,7 @@ public class NotificationDto {
                 .communityDto(new CommunityDto(vo.getCommunityId(), vo.getCommunityName()))
                 .userDto(
                         new UserDto(
-                                vo.getFromUserId(),
+                                vo.getFromIdCardId(),
                                 vo.getFromUserProfileImageUrl(),
                                 vo.getFromUserNickname()))
                 .commentDto(new CommentDto(vo.getCommentId(), vo.getComment()))

--- a/Api/src/main/java/com/dingdong/api/notification/dto/UserDto.java
+++ b/Api/src/main/java/com/dingdong/api/notification/dto/UserDto.java
@@ -8,8 +8,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class UserDto {
-    @Schema(description = "상대방 유저 고유값")
-    private Long fromUserId;
+    @Schema(description = "상대방 유저 주민증 고유값")
+    private Long fromIdCard;
 
     @Schema(description = "상대방 프로필 이미지")
     private String fromUserProfileImageUrl;

--- a/Api/src/main/java/com/dingdong/api/notification/service/NotificationService.java
+++ b/Api/src/main/java/com/dingdong/api/notification/service/NotificationService.java
@@ -111,14 +111,14 @@ public class NotificationService {
 
     @Transactional
     public void createAndPublishNotification(
-            Long userId,
+            Long toUserId,
             Long fromUserIdCardId,
             NotificationType type,
             NotificationContent content) {
-        if (Objects.equals(userHelper.getCurrentUser().getId(), userId)) {
+        if (Objects.equals(userHelper.getCurrentUser().getId(), toUserId)) {
             return;
         }
-        Notification notification = Notification.create(userId, fromUserIdCardId, type, content);
+        Notification notification = Notification.create(toUserId, fromUserIdCardId, type, content);
         notificationAdaptor.save(notification);
         applicationEventPublisher.publishEvent(notification);
     }

--- a/Api/src/main/java/com/dingdong/api/notification/service/NotificationService.java
+++ b/Api/src/main/java/com/dingdong/api/notification/service/NotificationService.java
@@ -111,11 +111,14 @@ public class NotificationService {
 
     @Transactional
     public void createAndPublishNotification(
-            Long userId, NotificationType type, NotificationContent content) {
+            Long userId,
+            Long fromUserIdCardId,
+            NotificationType type,
+            NotificationContent content) {
         if (Objects.equals(userHelper.getCurrentUser().getId(), userId)) {
             return;
         }
-        Notification notification = Notification.create(userId, type, content);
+        Notification notification = Notification.create(userId, fromUserIdCardId, type, content);
         notificationAdaptor.save(notification);
         applicationEventPublisher.publishEvent(notification);
     }

--- a/Api/src/main/java/com/dingdong/api/user/service/UserService.java
+++ b/Api/src/main/java/com/dingdong/api/user/service/UserService.java
@@ -71,8 +71,8 @@ public class UserService {
         currentUser.withdraw();
     }
 
-    private void deleteUserNotification(Long userId) {
-        notificationAdaptor.deleteAll(notificationAdaptor.findByUserId(userId));
+    private void deleteUserNotification(Long toUserId) {
+        notificationAdaptor.deleteAll(notificationAdaptor.findByToUserId(toUserId));
     }
 
     private void deleteUserIdCards(List<IdCard> idCards) {

--- a/Domain/src/main/java/com/dingdong/domain/domains/notification/adaptor/NotificationAdaptor.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/notification/adaptor/NotificationAdaptor.java
@@ -31,8 +31,8 @@ public class NotificationAdaptor {
         return notificationRepository.existsUnreadNotification(userId);
     }
 
-    public List<Notification> findByUserId(Long userId) {
-        return notificationRepository.findAllByUserId(userId);
+    public List<Notification> findByToUserId(Long toUserId) {
+        return notificationRepository.findAllByToUserId(toUserId);
     }
 
     public void deleteAll(List<Notification> notifications) {

--- a/Domain/src/main/java/com/dingdong/domain/domains/notification/domain/entity/Notification.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/notification/domain/entity/Notification.java
@@ -30,7 +30,9 @@ public class Notification extends AbstractTimeStamp {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @NotNull private Long userId;
+    @NotNull private Long toUserId;
+
+    @NotNull private Long fromUserIdCardId;
 
     @Enumerated(EnumType.STRING)
     @NotNull
@@ -43,29 +45,35 @@ public class Notification extends AbstractTimeStamp {
     private NotificationStatus notificationStatus = NotificationStatus.UNREAD;
 
     public void read(Long userId) {
-        if (this.userId != userId) {
+        if (this.toUserId != userId) {
             throw new BaseException(NO_AUTHORITY_UPDATE_NOTIFICATION);
         }
         this.notificationStatus = NotificationStatus.READ;
     }
 
     private Notification(
-            Long userId, NotificationType notificationType, NotificationContent content) {
-        this.userId = userId;
+            Long toUserId,
+            Long fromUserIdCardId,
+            NotificationType notificationType,
+            NotificationContent content) {
+        this.toUserId = toUserId;
+        this.fromUserIdCardId = fromUserIdCardId;
         this.notificationType = notificationType;
         this.content = content;
     }
 
     public static Notification create(
-            Long userId,
+            Long toUserId,
+            Long fromUserIdCardId,
             NotificationType notificationType,
             NotificationContent notificationContent) {
         return new Notification(
-                userId,
+                toUserId,
+                fromUserIdCardId,
                 notificationType,
                 NotificationContent.create(
                         notificationContent.getCommunityId(),
-                        notificationContent.getFromUserId(),
+                        notificationContent.getIdCardId(),
                         notificationContent.getCommentId()));
     }
 }

--- a/Domain/src/main/java/com/dingdong/domain/domains/notification/domain/model/NotificationContent.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/notification/domain/model/NotificationContent.java
@@ -22,7 +22,7 @@ public class NotificationContent {
         this.commentId = commentId;
     }
 
-    public static NotificationContent create(Long communityId, Long fromUserId, Long commentId) {
-        return new NotificationContent(communityId, fromUserId, commentId);
+    public static NotificationContent create(Long communityId, Long fromIdCardId, Long commentId) {
+        return new NotificationContent(communityId, fromIdCardId, commentId);
     }
 }

--- a/Domain/src/main/java/com/dingdong/domain/domains/notification/domain/model/NotificationContent.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/notification/domain/model/NotificationContent.java
@@ -6,23 +6,24 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/** 알림의 타겟이 되는 필드들 */
 @Embeddable
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NotificationContent {
     private Long communityId;
 
-    private Long fromUserId;
+    private Long idCardId;
 
     private Long commentId;
 
-    private NotificationContent(Long communityId, Long fromUserId, Long commentId) {
+    private NotificationContent(Long communityId, Long idCardId, Long commentId) {
         this.communityId = communityId;
-        this.fromUserId = fromUserId;
+        this.idCardId = idCardId;
         this.commentId = commentId;
     }
 
-    public static NotificationContent create(Long communityId, Long fromIdCardId, Long commentId) {
-        return new NotificationContent(communityId, fromIdCardId, commentId);
+    public static NotificationContent create(Long communityId, Long idCardId, Long commentId) {
+        return new NotificationContent(communityId, idCardId, commentId);
     }
 }

--- a/Domain/src/main/java/com/dingdong/domain/domains/notification/domain/vo/NotificationVO.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/notification/domain/vo/NotificationVO.java
@@ -21,7 +21,7 @@ public class NotificationVO {
 
     private final String communityName;
 
-    private final Long fromUserId;
+    private final Long fromIdCardId;
 
     private final String fromUserProfileImageUrl;
 
@@ -41,7 +41,7 @@ public class NotificationVO {
             Timestamp createdAt,
             Long communityId,
             String communityName,
-            Long fromUserId,
+            Long fromIdCardId,
             String fromUserProfileImageUrl,
             String fromUserNickname,
             Long commentId,
@@ -53,7 +53,7 @@ public class NotificationVO {
         this.createdAt = createdAt;
         this.communityId = communityId;
         this.communityName = communityName;
-        this.fromUserId = fromUserId;
+        this.fromIdCardId = fromIdCardId;
         this.fromUserProfileImageUrl = fromUserProfileImageUrl;
         this.fromUserNickname = fromUserNickname;
         this.commentId = commentId;

--- a/Domain/src/main/java/com/dingdong/domain/domains/notification/repository/NotificationRepository.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/notification/repository/NotificationRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationRepository
         extends JpaRepository<Notification, Long>, NotificationRepositoryExtension {
-    List<Notification> findAllByUserId(Long userId);
+    List<Notification> findAllByToUserId(Long toUserId);
 }

--- a/Domain/src/main/java/com/dingdong/domain/domains/notification/repository/NotificationRepositoryImpl.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/notification/repository/NotificationRepositoryImpl.java
@@ -36,8 +36,7 @@ public class NotificationRepositoryImpl implements NotificationRepositoryExtensi
                 .on(notification.content.commentId.eq(comment.id))
                 .where(
                         notification.userId.eq(userId),
-                        notification.createdAt.after(NotificationRepositoryImpl.FIVE_WEEKS_AGO),
-                        comment.userId.ne(userId))
+                        notification.createdAt.after(NotificationRepositoryImpl.FIVE_WEEKS_AGO))
                 .groupBy(notification.id);
     }
 

--- a/Domain/src/main/java/com/dingdong/domain/domains/notification/repository/NotificationRepositoryImpl.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/notification/repository/NotificationRepositoryImpl.java
@@ -31,11 +31,11 @@ public class NotificationRepositoryImpl implements NotificationRepositoryExtensi
                 .join(community)
                 .on(notification.content.communityId.eq(community.id))
                 .join(idCard)
-                .on(notification.content.fromUserId.eq(idCard.userInfo.userId))
+                .on(notification.fromUserIdCardId.eq(idCard.id))
                 .join(comment)
                 .on(notification.content.commentId.eq(comment.id))
                 .where(
-                        notification.userId.eq(userId),
+                        notification.toUserId.eq(userId),
                         notification.createdAt.after(NotificationRepositoryImpl.FIVE_WEEKS_AGO))
                 .groupBy(notification.id);
     }
@@ -52,12 +52,12 @@ public class NotificationRepositoryImpl implements NotificationRepositoryExtensi
                                         notification.createdAt,
                                         community.id,
                                         community.name,
-                                        notification.content.fromUserId,
+                                        notification.fromUserIdCardId,
                                         idCard.userInfo.profileImageUrl,
                                         idCard.userInfo.nickname,
                                         community.id,
                                         comment.content,
-                                        idCard.id))
+                                        comment.idCardId))
                         .orderBy(notification.id.desc())
                         .offset(pageable.getOffset())
                         .limit(pageable.getPageSize() + 1)


### PR DESCRIPTION
## 개요
- [DEP-196](https://darae0730.atlassian.net/browse/DEP-196): 알람과 행성내 주민 이름 불일치 에러 해결

## 작업사항
```
[경로]
주민증 상세 / 알림

[진행]
주민증 상세에서 댓글을 받고 알림창에서 확인한다

[기대]
각 행성에서 설정된 이름이 알림에서도 동일하게 보여진다

[오류]
한 사람과 여러 행성에 함께 속해있을 경우에, 이름이 모두 동일하게 보여요
( 행성에서 설정해둔 이름은 김선우인데 알람에서는 김채린으로 떠요)

[수정되어야 할 부분 (요청사항)]
행성 별로 설정된 이름이 알람에서 동일하게 보여지게 해주세요!
```

## 변경사항
- 알람 생성 시 주민증의 Id가 아닌 유저의 Id를 넣고 저장하고 있어서 변경
- 댓글 좋아요 알림 조회 안되던 문제 해결
- 알림 테이블 수정


## DDL
```sql
ALTER TABLE tbl_notification
RENAME COLUMN from_user_id TO from_user_id_card_id,
RENAME COLUMN user_id TO to_user_id;

ALTER TABLE tbl_notification
ADD COLUMN id_card_id bigint NULL;
```