### PR TITLE
DEP-197: 페이징 시 hasNext 항상 false 반환하는 문제 해결 

### DIFF
--- a/Api/src/main/java/com/dingdong/api/community/service/CommunityService.java
+++ b/Api/src/main/java/com/dingdong/api/community/service/CommunityService.java
@@ -101,7 +101,7 @@ public class CommunityService {
 
         Slice<IdCard> idCards = idCardAdaptor.findIdCardByConditionInPage(communityId, pageable);
 
-        return SliceUtil.valueOf(
+        return SliceUtil.createSliceWithPageable(
                 idCards.stream()
                         .map(
                                 idCard ->

--- a/Api/src/main/java/com/dingdong/api/idcard/service/CommentService.java
+++ b/Api/src/main/java/com/dingdong/api/idcard/service/CommentService.java
@@ -104,7 +104,7 @@ public class CommentService {
                 commentAdaptor.findCommentsByIdCard(
                         idCard.getId(), idCard.getCommunityId(), pageable);
 
-        return SliceUtil.valueOf(
+        return SliceUtil.createSliceWithPageable(
                 comments.stream()
                         .map(
                                 commentVo ->

--- a/Api/src/main/java/com/dingdong/api/notification/service/NotificationService.java
+++ b/Api/src/main/java/com/dingdong/api/notification/service/NotificationService.java
@@ -92,7 +92,7 @@ public class NotificationService {
         List<NotificationDto> notificationDtos =
                 notificationByConditionInPage.stream().map(NotificationDto::from).toList();
 
-        return SliceUtil.valueOf(notificationDtos, notificationByConditionInPage.getPageable());
+        return SliceUtil.createSliceWithPageable(notificationDtos, pageable);
     }
 
     @Transactional

--- a/Domain/src/main/java/com/dingdong/domain/common/util/SliceUtil.java
+++ b/Domain/src/main/java/com/dingdong/domain/common/util/SliceUtil.java
@@ -10,11 +10,16 @@ import org.springframework.data.domain.SliceImpl;
 @UtilityClass
 public class SliceUtil {
 
-    // 리스트를 슬라이스로 변환
-    public static <T> Slice<T> valueOf(List<T> contents, Pageable pageable) {
+    // 리스트를 슬라이스로 변환(비즈니스 로직)
+    public static <T> Slice<T> createSliceWithPageable(List<T> contents, Pageable pageable) {
         boolean hasNext = hasNext(contents, pageable);
         return new SliceImpl<>(
                 hasNext ? getContent(contents, pageable) : contents, pageable, hasNext);
+    }
+
+    // 리스트를 슬라이스로 변환(쿼리)
+    public static <T> Slice<T> createSliceWithoutPageable(List<T> contents) {
+        return new SliceImpl<>(contents);
     }
 
     // 다음 페이지 있는지 확인

--- a/Domain/src/main/java/com/dingdong/domain/domains/idcard/repository/CommentRepositoryImpl.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/idcard/repository/CommentRepositoryImpl.java
@@ -37,7 +37,7 @@ public class CommentRepositoryImpl implements CommentRepositoryExtension {
                         .limit(pageable.getPageSize() + 1)
                         .fetch();
 
-        return SliceUtil.valueOf(comments, pageable);
+        return SliceUtil.createSliceWithoutPageable(comments);
     }
 
     @Override

--- a/Domain/src/main/java/com/dingdong/domain/domains/idcard/repository/IdCardRepositoryImpl.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/idcard/repository/IdCardRepositoryImpl.java
@@ -28,6 +28,6 @@ public class IdCardRepositoryImpl implements IdCardRepositoryExtension {
                         .limit(pageable.getPageSize() + 1)
                         .fetch();
 
-        return SliceUtil.valueOf(idCards, pageable);
+        return SliceUtil.createSliceWithoutPageable(idCards);
     }
 }

--- a/Domain/src/main/java/com/dingdong/domain/domains/notification/repository/NotificationRepositoryImpl.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/notification/repository/NotificationRepositoryImpl.java
@@ -63,7 +63,7 @@ public class NotificationRepositoryImpl implements NotificationRepositoryExtensi
                         .limit(pageable.getPageSize() + 1)
                         .fetch();
 
-        return SliceUtil.valueOf(notificationVOs, pageable);
+        return SliceUtil.createSliceWithoutPageable(notificationVOs);
     }
 
     @Override


### PR DESCRIPTION
## 개요
- [DEP-197](https://darae0730.atlassian.net/browse/DEP-197): 페이징 시 hasNext 항상 false 반환하는 문제 해결 

## 작업사항
- 페이징 시 hasNext를 항상 false로 내려주던 문제를 해결했습니다.

## 변경로직
기존에 ```xxxRepositoryImpl```에서 ```hasNext``` 처리를 위해 ```.limit(pageable.getPageSize() + 1)```를 통해 데이터를 하나 더 불러오고```return SliceUtil.valueOf(contents, pageable)``` 처리를 하는데, 여기서 아래 로직들에 의해 ```hasNext```가 ```true``` 이면, 기존에 하나 더 불러왔던 데이터를 제거합니다. ```return content.subList(0, pageable.getPageSize());```
```java
@UtilityClass
public class SliceUtil {

    // 리스트를 슬라이스로 변환
    public static <T> Slice<T> valueOf(List<T> contents, Pageable pageable) {
        boolean hasNext = hasNext(contents, pageable);
        return new SliceImpl<>(
                hasNext ? getContent(contents, pageable) : contents, pageable, hasNext);
    }

    // 다음 페이지 있는지 확인
    private static <T> boolean hasNext(List<T> content, Pageable pageable) {
        return pageable.isPaged() && content.size() > pageable.getPageSize();
    }

    // 데이터 1개 빼고 반환
    private static <T> List<T> getContent(List<T> content, Pageable pageable) {
        return content.subList(0, pageable.getPageSize());
    }
}
```

여기까지는 문제가 없지만 저희 비즈니스 로직을 보면 ```Response``` 변환을 위해 ```SliceUtil.valueOf(contents, pageable)```를 한 번 더 사용하는데, 여기서 데이터 크기는 한 개 제거가 된 상태이기 때문에 ```hasNext```를 항상 ```false```로 세팅하게 되는 문제가 발생합니다.


그래서 valueOf를 두개 만들어서 비즈니스 로직에서만 hasNext를 세팅하도록 변경했습니다.