### PR TITLE
DEP-198: S3 delete API 이벤트처리

### DIFF
--- a/Api/src/main/java/com/dingdong/api/global/event/EventListener.java
+++ b/Api/src/main/java/com/dingdong/api/global/event/EventListener.java
@@ -2,7 +2,9 @@ package com.dingdong.api.global.event;
 
 
 import com.dingdong.api.notification.service.NotificationService;
+import com.dingdong.domain.domains.image.domain.entity.DeleteImage;
 import com.dingdong.domain.domains.notification.domain.entity.Notification;
+import com.dingdong.infrastructure.image.ImageHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
@@ -12,9 +14,15 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 public class EventListener {
     private final NotificationService notificationService;
+    private final ImageHandler imageHandler;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
-    public void notify(Notification notification) {
+    public void notifyAfterCommit(Notification notification) {
         notificationService.notify(notification.getToUserId(), true);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    public void deleteS3ImageAfterCommit(DeleteImage deleteImage) {
+        imageHandler.removeImage(deleteImage.getImageUrl());
     }
 }

--- a/Infrastructure/src/main/java/com/dingdong/infrastructure/image/s3/S3ImageService.java
+++ b/Infrastructure/src/main/java/com/dingdong/infrastructure/image/s3/S3ImageService.java
@@ -5,14 +5,17 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.dingdong.infrastructure.image.ImageHandler;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class S3ImageService implements ImageHandler {
 
     @Value("${aws.s3.bucket}")
@@ -27,9 +30,14 @@ public class S3ImageService implements ImageHandler {
         return s3Api.uploadImage(bucket, fileName, multipartFile, objectMetadata);
     }
 
+    @Async
     public void removeImage(String imageUrl) {
         String fileName = imageUrl.substring(imageUrl.lastIndexOf('/') + 1);
-        s3Api.removeImage(bucket, fileName);
+        try {
+            s3Api.removeImage(bucket, fileName);
+        } catch (RuntimeException e) {
+            log.error("imageUrl: {}, errorMessage: {}", imageUrl, e.getMessage());
+        }
     }
 
     private String createFileName(String fileName) {


### PR DESCRIPTION
## 개요
- [DEP-198](https://darae0730.atlassian.net/browse/DEP-198): S3 delete API 이벤트처리

## 작업사항
- S3 이미지 제거 부분 이벤트 처리하도록 변경했습니다.

cc. https://dkswnkk.tistory.com/704

추가로 생각해보니 아래와 같은 시나리오일 경우 삭제할 이미지가 추적이 안되더라구요
- 프론트에서 이미지 등록 API 요청 후 url A생성
- 해당 url을 이미지로 사용하지 않고 새로운 url B생성
- url B를 행성 혹은 주민증 등에 사용
=> url A는 더 이상 추적이 되지 않음

요 시나리오에 대해서 한번 생각해 봐야 할 것 같아요 

그리고 개인적으로 이미지 리사이징 기능도 추가해 보고 싶은데, 저도 요건 저도 안 해봐서 혹시 경험 있으시거나 욕심 있으신 분 있으면 같이 해욤^__^