### PR TITLE
Dep 199-데모데이용 workaround 코드 작성

### DIFF
--- a/Api/src/main/java/com/dingdong/api/user/service/UserService.java
+++ b/Api/src/main/java/com/dingdong/api/user/service/UserService.java
@@ -10,6 +10,8 @@ import com.dingdong.core.consts.StaticVal;
 import com.dingdong.core.exception.BaseException;
 import com.dingdong.domain.domains.community.adaptor.CommunityAdaptor;
 import com.dingdong.domain.domains.community.domain.entity.Community;
+import com.dingdong.domain.domains.community.domain.entity.UserJoinCommunity;
+import com.dingdong.domain.domains.community.validator.CommunityValidator;
 import com.dingdong.domain.domains.idcard.adaptor.CommentAdaptor;
 import com.dingdong.domain.domains.idcard.adaptor.IdCardAdaptor;
 import com.dingdong.domain.domains.idcard.domain.entity.Comment;
@@ -38,6 +40,7 @@ public class UserService {
     private final CommentAdaptor commentAdaptor;
     private final ImageAdaptor imageAdaptor;
     private final CommunityAdaptor communityAdaptor;
+    private final CommunityValidator communityValidator;
     private final NotificationAdaptor notificationAdaptor;
 
     public UserProfileDto getUserProfile() {
@@ -52,6 +55,11 @@ public class UserService {
         CharacterType characterType = findCharacterType(request.getCharacter());
         user.updateCharacter(Character.toEntity(characterType));
         user.updateProfileImage(StaticVal.getDefaultProfileImage(String.valueOf(characterType)));
+
+        // workAround (유저 회원가입 시 행성 1번 자동 가입)
+        if (communityValidator.validateUserJoinDefaultCommunity(user.getId(), 1L)) {
+            communityAdaptor.userJoinCommunity(UserJoinCommunity.toEntity(user.getId(), 1L));
+        }
     }
 
     @Transactional

--- a/Api/src/main/java/com/dingdong/api/user/service/UserService.java
+++ b/Api/src/main/java/com/dingdong/api/user/service/UserService.java
@@ -57,7 +57,7 @@ public class UserService {
         user.updateProfileImage(StaticVal.getDefaultProfileImage(String.valueOf(characterType)));
 
         // workAround (유저 회원가입 시 행성 1번 자동 가입)
-        if (communityValidator.validateUserJoinDefaultCommunity(user.getId(), 1L)) {
+        if (!communityValidator.validateUserJoinDefaultCommunity(user.getId(), 1L)) {
             communityAdaptor.userJoinCommunity(UserJoinCommunity.toEntity(user.getId(), 1L));
         }
     }

--- a/Domain/src/main/java/com/dingdong/domain/domains/community/adaptor/CommunityAdaptor.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/community/adaptor/CommunityAdaptor.java
@@ -14,6 +14,7 @@ import com.dingdong.domain.domains.community.repository.CommunityRepository;
 import com.dingdong.domain.domains.community.repository.UserJoinCommunityRepository;
 import com.dingdong.domain.domains.user.domain.entity.User;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 
 @Adaptor
@@ -81,6 +82,11 @@ public class CommunityAdaptor {
         return userJoinCommunityRepository
                 .findByUserIdAndCommunityId(user.getId(), community.getId())
                 .orElseThrow(() -> new BaseException(NOT_JOIN_COMMUNITY));
+    }
+
+    public Optional<UserJoinCommunity> findByUserAndCommunityForValidate(
+            Long userId, Long communityId) {
+        return userJoinCommunityRepository.findByUserIdAndCommunityId(userId, communityId);
     }
 
     public void deleteUserJoinCommunity(UserJoinCommunity userJoinCommunity) {

--- a/Domain/src/main/java/com/dingdong/domain/domains/community/adaptor/CommunityAdaptor.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/community/adaptor/CommunityAdaptor.java
@@ -75,7 +75,7 @@ public class CommunityAdaptor {
         List<Long> communities =
                 findByUser(user).stream().map(UserJoinCommunity::getCommunityId).toList();
 
-        return communityRepository.findAllByIdIn(communities);
+        return communityRepository.findAllByIdInOrderByIdDesc(communities);
     }
 
     public UserJoinCommunity findByUserAndCommunity(User user, Community community) {

--- a/Domain/src/main/java/com/dingdong/domain/domains/community/repository/CommunityRepository.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/community/repository/CommunityRepository.java
@@ -18,5 +18,5 @@ public interface CommunityRepository
 
     boolean existsCommunityById(Long id);
 
-    List<Community> findAllByIdIn(List<Long> communitiesId);
+    List<Community> findAllByIdInOrderByIdDesc(List<Long> communitiesId);
 }

--- a/Domain/src/main/java/com/dingdong/domain/domains/community/validator/CommunityValidator.java
+++ b/Domain/src/main/java/com/dingdong/domain/domains/community/validator/CommunityValidator.java
@@ -62,4 +62,8 @@ public class CommunityValidator {
             throw new BaseException(NOT_FOUND_COMMUNITY);
         }
     }
+
+    public boolean validateUserJoinDefaultCommunity(Long userId, Long communityId) {
+        return communityAdaptor.findByUserAndCommunityForValidate(userId, communityId).isPresent();
+    }
 }


### PR DESCRIPTION
## 개요
- [DEP-199](https://darae0730.atlassian.net/jira/software/c/projects/DEP/boards/2/timeline?selectedIssue=DEP-199)를 했어용

## 작업사항
- 어제 혜현님이 말씀하신 부분들을 작업했습니다
- 가입 시 디폴트 행성 (id 1번) 자동 가입 처리 => 회원가입 시점으로 할까 하다가 유저 캐릭터가 아직 없기도 하고 어차피 꼭 타야하는 플로우라서 해당 로직에 박아넣었습니당
``` JAVA
   @Transactional
    public void saveUserCharacter(UserCharacterRequest request) {
        User user = userHelper.getCurrentUser();
        CharacterType characterType = findCharacterType(request.getCharacter());
        user.updateCharacter(Character.toEntity(characterType));
        user.updateProfileImage(StaticVal.getDefaultProfileImage(String.valueOf(characterType)));

        // workAround (유저 회원가입 시 행성 1번 자동 가입)
        if (!communityValidator.validateUserJoinDefaultCommunity(user.getId(), 1L)) {
            communityAdaptor.userJoinCommunity(UserJoinCommunity.toEntity(user.getId(), 1L));
        }
    }
```
- 유저가 가입한 행성 리스트 조회 시 정렬 조건 변경 id desc로
- 데모데이용 코드이기때문에 데모데이 끝나고는 삭제할 거기도 하고 저희 이제 출시할 때는 버전관리도 할겸 main 브랜치 파고 액션 스크립트 좀 수정해서 도커 올릴 때 버저닝하면 어떨까 하는데 어떻게 생각하세용
## 변경로직
- 내용을 적어주세요.